### PR TITLE
Fix focus keyword handling

### DIFF
--- a/js/bulk-meta-editor.js
+++ b/js/bulk-meta-editor.js
@@ -1,19 +1,23 @@
 jQuery(document).ready(function($) {
     var changes = {};
 
-    $('td.editable').click(function() {
+    $('td.editable').on('click', function() {
+        // Prevent clearing existing content if the cell is already being edited
+        if ($(this).hasClass('cellEditing')) {
+            return;
+        }
+
         var originalContent = $(this).text();
         var postId = $(this).parent().data('post-id');
         var metaKey = $(this).data('meta-key');
 
-        $(this).addClass("cellEditing");
-        $(this).html("<input type='text' value='" + originalContent + "' />");
-        $(this).children().first().focus();
-
-        $(this).children().first().blur(function() {
+        $(this).addClass('cellEditing');
+        $(this).html('<textarea>' + originalContent + '</textarea>');
+        $(this).children('textarea').focus().one('blur', function() {
             var newContent = $(this).val();
-            $(this).parent().text(newContent);
-            $(this).parent().removeClass("cellEditing");
+            var $parent = $(this).parent();
+            $parent.text(newContent);
+            $parent.removeClass('cellEditing');
 
             if (!changes[postId]) {
                 changes[postId] = {};

--- a/seo-bulk-meta-editor.php
+++ b/seo-bulk-meta-editor.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Yoast SEO Bulk Meta Editor
  * Description: Display & edit all meta titles, descriptions, and keywords from all posts, pages, and custom post types into one dashboard.
- * Version: 1.0
+ * Version: 1.0.1
  * Plugin URI: https://nomad-developer.co.uk
  * Author: Nomad Developer
  * Author URI:  https://nomad-developer.co.uk
@@ -61,9 +61,16 @@ function yoast_bulk_meta_editor_page()
         $page_title_link = get_edit_post_link($post->ID);
         $post_type = get_post_type($post->ID);
         $post_meta_description = get_post_meta($post->ID, '_yoast_wpseo_metadesc', true);
-        $post_meta_keywords = get_post_meta($post->ID, '_yoast_wpseo_focuskw_text_input', true);
+        // Fetch the Yoast focus keyphrase for the post.
+        // Yoast stores the focus keyphrase in the _yoast_wpseo_focuskw meta key.
+        // Previous versions of this plugin attempted to read the value from
+        // `_yoast_wpseo_focuskw_text_input`, which no longer exists in recent
+        // versions of Yoast SEO and resulted in keywords not appearing in the
+        // table. Using the correct meta key ensures that the current value is
+        // displayed and can be updated properly.
+        $post_meta_keywords = get_post_meta($post->ID, '_yoast_wpseo_focuskw', true);
         $post_meta_title = get_post_meta($post->ID, '_yoast_wpseo_title', true);
-        echo '<tr data-post-id="' . $post->ID . '"><td><a href="' . $page_title_link . '">'. $page_title . '</a></td><td>' . ucfirst($post_type) . '</td><td class="editable" data-meta-key="_yoast_wpseo_title">' . $post_meta_title . '</td><td class="editable" data-meta-key="_yoast_wpseo_metadesc">' . $post_meta_description . '</td><td class="editable" data-meta-key="_yoast_wpseo_focuskw_text_input">' . $post_meta_keywords . '</td></tr>';
+        echo '<tr data-post-id="' . $post->ID . '"><td><a href="' . $page_title_link . '">'. $page_title . '</a></td><td>' . ucfirst($post_type) . '</td><td class="editable" data-meta-key="_yoast_wpseo_title">' . $post_meta_title . '</td><td class="editable" data-meta-key="_yoast_wpseo_metadesc">' . $post_meta_description . '</td><td class="editable" data-meta-key="_yoast_wpseo_focuskw">' . $post_meta_keywords . '</td></tr>';
     }
     echo '</tbody>';
     echo '</table>';


### PR DESCRIPTION
## Summary
- fix meta key for Yoast focus keyword
- bump plugin version to 1.0.1
- edit cells using a textarea and prevent double-click from clearing text

## Testing
- `php -l seo-bulk-meta-editor.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849a2cf79ac8324bac44f13adcc5810