### PR TITLE
Add settings for extra Yoast columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Yoast SEO Bulk Meta Editor is a small WordPress plugin that adds a dedicated adm
 - View all Yoast SEO meta titles, descriptions and keywords in one place
 - Edit meta fields inline and save all changes at once via AJAX
 - Responsive table with "Load More" support for large datasets
-- Choose which post types are included from the plugin's **Settings** page
+- Choose which post types and table columns are included from the plugin's **Settings** page
 - Requires the [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/) plugin to be installed and active
 
 ## Installation
@@ -21,7 +21,7 @@ Yoast SEO Bulk Meta Editor is a small WordPress plugin that adds a dedicated adm
 1. In the WordPress admin, open **Yoast Bulk Meta Editor** from the main menu
 2. Edit the meta title, description or keyword by clicking a table cell
 3. After editing, click **Save Changes** to store the updates
-4. Use **Yoast Bulk Meta Editor → Settings** to select which post types are shown
+4. Use **Yoast Bulk Meta Editor → Settings** to choose which post types and columns are shown in the table
 
 ## Contributing
 

--- a/js/bulk-meta-editor.js
+++ b/js/bulk-meta-editor.js
@@ -8,7 +8,10 @@ jQuery(document).ready(function($) {
         changeHistory.push({postId: postId, metaKey: metaKey, oldValue: oldValue, newValue: newValue});
         var label = metaKey === '_yoast_wpseo_title' ? 'Title' :
                     metaKey === '_yoast_wpseo_metadesc' ? 'Meta Description' :
-                    'Keyword';
+                    metaKey === '_yoast_wpseo_focuskw' ? 'Keyword' :
+                    metaKey === '_yoast_wpseo_canonical' ? 'Canonical URL' :
+                    metaKey === '_yoast_wpseo_opengraph-title' ? 'Social Title' :
+                    metaKey;
         $('#history-log').append('<li>' + label + ' for post ' + postId + ' updated.</li>');
     }
 
@@ -69,7 +72,7 @@ jQuery(document).ready(function($) {
         $(this).addClass('cellEditing');
 
         var limit = null;
-        if (metaKey === '_yoast_wpseo_title') {
+        if (metaKey === '_yoast_wpseo_title' || metaKey === '_yoast_wpseo_opengraph-title') {
             limit = 60;
         } else if (metaKey === '_yoast_wpseo_metadesc') {
             limit = 160;


### PR DESCRIPTION
## Summary
- expose canonical URL and social title columns
- allow enabling/disabling columns from settings
- update JS for new columns and limits
- document new option in README

## Testing
- `php -l seo-bulk-meta-editor.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849ae3ad0ac83249fe11d3a9024c858