### PR TITLE
Add PRO CSV meta tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,21 @@
 # Yoast SEO Bulk Meta Editor
 
+## v1.3.0 → v1.4.0
+
 Yoast SEO Bulk Meta Editor is a small WordPress plugin that adds a dedicated admin page for managing Yoast SEO metadata in bulk. It displays the title, meta description and focus keyword for each post, page and any public custom post type in a sortable table so you can update multiple entries quickly.
 
 ## Features
 
+### Free
 - View all Yoast SEO meta titles, descriptions and keywords in one place
 - Edit meta fields inline and save all changes at once via AJAX
 - Responsive table with "Load More" support for large datasets
 - Choose which post types and table columns are included from the plugin's **Settings** page
 - The post type filter dropdown only lists the post types selected in **Settings**
 - Requires the [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/) plugin to be installed and active
+
+### Premium
+- CSV Meta Tools (PRO) for fast import/export of metadata
 
 ## Installation
 

--- a/css/style.css
+++ b/css/style.css
@@ -99,3 +99,15 @@
     margin-top: 20px;
     text-align: left;
 }
+
+.ybme-upsell {
+    border: 2px dashed #ffba00;
+    background: #fffbe5;
+    padding: 15px;
+    margin-top: 20px;
+    text-align: center;
+}
+
+.ybme-upsell-subtext {
+    margin-top: 10px;
+}

--- a/seo-bulk-meta-editor.php
+++ b/seo-bulk-meta-editor.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Yoast SEO Bulk Meta Editor
  * Description: Display & edit all meta titles, descriptions, and keywords from all posts, pages, and custom post types into one dashboard.
- * Version: 1.2.1
+ * Version: 1.4.0
  * Plugin URI: https://nomad-developer.co.uk
  * Author: Nomad Developer
  * Author URI:  https://nomad-developer.co.uk
@@ -31,6 +31,11 @@ function ybme_get_enabled_columns() {
     return array_unique(array_merge($defaults, $saved));
 }
 
+function ybme_is_pro() {
+    $key = trim(get_option('ybme_license_key'));
+    return !empty($key);
+}
+
 
 // Check for Yoast SEO plugin on activation
 register_activation_hook(__FILE__, 'check_for_yoast_seo');
@@ -52,6 +57,9 @@ function yoast_bulk_meta_editor_create_menu() {
 
     // Create submenu for settings
     add_submenu_page('yoast-bulk-meta-editor', 'Yoast Bulk Meta Editor Settings', 'Settings', 'manage_options', 'yoast-bulk-meta-editor-settings', 'yoast_bulk_meta_editor_settings_page');
+
+    // CSV import/export page (PRO)
+    add_submenu_page('yoast-bulk-meta-editor', 'CSV Import/Export', 'CSV Import/Export (PRO)', 'manage_options', 'yoast-bulk-meta-editor-csv', 'ybme_csv_tools_page');
 
     // Call register settings function
     add_action('admin_init', 'register_yoast_bulk_meta_editor_settings');
@@ -179,6 +187,8 @@ function yoast_bulk_meta_editor_page()
 function register_yoast_bulk_meta_editor_settings() {
     register_setting('yoast-bulk-meta-editor-settings-group', 'post_types');
     register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_enabled_columns');
+    register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_license_key');
+    register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_delete_on_blank');
 }
 
 // Create settings page
@@ -214,6 +224,25 @@ function yoast_bulk_meta_editor_settings_page() {
                     echo '<label for="col_' . $key . '">' . esc_html($info['label']) . '</label><br>';
                 }
             ?>
+
+            <h2 style="margin-top:20px;">License Key (PRO):</h2>
+            <?php
+                $license = esc_attr(get_option('ybme_license_key', ''));
+                echo '<input type="text" style="width:300px;" name="ybme_license_key" value="' . $license . '" placeholder="Enter license key" />';
+            ?>
+
+            <h2 style="margin-top:20px;">Import Options:</h2>
+            <?php
+                $del = get_option('ybme_delete_on_blank', 0);
+                echo '<label><input type="checkbox" name="ybme_delete_on_blank" value="1"' . checked(1, $del, false) . '> Delete meta values when CSV cells are blank</label>';
+            ?>
+
+            <div class="ybme-upsell">
+                <p><strong>Bulk-edit metadata in seconds</strong></p>
+                <p><strong>Offline backups you can trust</strong></p>
+                <p><strong>Boost your WP workflow</strong></p>
+                <p class="ybme-upsell-subtext"><strong>Why go PRO?</strong><br/>Unlock CSV import/export and secure backups for rapid SEO edits.</p>
+            </div>
 
             <?php submit_button(); ?>
         </form>
@@ -322,4 +351,149 @@ function yoast_bulk_meta_editor_load_more_posts()
     }
     wp_reset_postdata();
     wp_die();
+}
+
+function ybme_csv_tools_page() {
+    echo '<div class="wrap"><h1>CSV Import/Export</h1>';
+
+    if (!ybme_is_pro()) {
+        echo '<p>This feature is available in the PRO version. Enter your license key in Settings to enable it.</p></div>';
+        return;
+    }
+
+    if (isset($_POST['ybme_export_csv'])) {
+        ybme_export_csv();
+        exit;
+    }
+
+    if (isset($_POST['ybme_import_csv']) && !empty($_FILES['ybme_csv_file']['tmp_name'])) {
+        ybme_import_csv($_FILES['ybme_csv_file']);
+        echo '<div class="updated notice"><p>Import completed.</p></div>';
+    }
+
+    ?>
+    <form method="post">
+        <input type="hidden" name="ybme_export_csv" value="1" />
+        <?php submit_button('Export CSV'); ?>
+    </form>
+    <form method="post" enctype="multipart/form-data" style="margin-top:20px;">
+        <input type="file" name="ybme_csv_file" accept=".csv" required />
+        <?php submit_button('Import CSV'); ?>
+    </form>
+    </div>
+    <?php
+}
+
+function ybme_export_csv() {
+    global $wpdb;
+
+    $posts = get_posts([
+        'numberposts' => -1,
+        'post_type'   => get_option('post_types', ['post','page']),
+        'post_status' => 'any',
+        'orderby'     => 'ID',
+        'order'       => 'ASC'
+    ]);
+
+    if (empty($posts)) {
+        return;
+    }
+
+    $post_ids = wp_list_pluck($posts, 'ID');
+    $placeholders = implode(',', array_fill(0, count($post_ids), '%d'));
+    $meta_keys = [];
+    if ($placeholders) {
+        $query = $wpdb->prepare("SELECT DISTINCT meta_key FROM {$wpdb->postmeta} WHERE post_id IN ($placeholders)", $post_ids);
+        $meta_keys = $wpdb->get_col($query);
+    }
+    sort($meta_keys);
+
+    $headers = [
+        'post_id',
+        'post_type',
+        'post_title',
+        'post_slug',
+        'post_status',
+        'post_date',
+        'post_modified'
+    ];
+    foreach ($meta_keys as $k) {
+        $headers[] = 'meta_' . $k;
+    }
+
+    header('Content-Type: text/csv; charset=utf-8');
+    header('Content-Disposition: attachment; filename="ybme-export.csv"');
+    $out = fopen('php://output', 'w');
+    fputcsv($out, $headers);
+
+    foreach ($posts as $p) {
+        $row = [
+            $p->ID,
+            $p->post_type,
+            $p->post_title,
+            $p->post_name,
+            $p->post_status,
+            mysql2date('Y-m-d H:i:s', $p->post_date, false),
+            mysql2date('Y-m-d H:i:s', $p->post_modified, false)
+        ];
+
+        foreach ($meta_keys as $k) {
+            $val = get_post_meta($p->ID, $k, true);
+            if (is_array($val)) {
+                $val = implode('|', $val);
+            }
+            $row[] = $val;
+        }
+        fputcsv($out, $row);
+    }
+    fclose($out);
+}
+
+function ybme_import_csv($file) {
+    $delete = get_option('ybme_delete_on_blank', 0);
+
+    $handle = fopen($file['tmp_name'], 'r');
+    if (!$handle) {
+        return;
+    }
+    $header = fgetcsv($handle);
+    if (!$header) {
+        fclose($handle);
+        return;
+    }
+
+    $meta_cols = [];
+    foreach ($header as $index => $name) {
+        if (strpos($name, 'meta_') === 0) {
+            $meta_cols[$index] = substr($name, 5);
+        }
+    }
+    $post_index = array_search('post_id', $header);
+
+    while (($row = fgetcsv($handle)) !== false) {
+        $post_id = ($post_index !== false && isset($row[$post_index])) ? intval($row[$post_index]) : 0;
+        if (!$post_id) {
+            continue;
+        }
+
+        foreach ($meta_cols as $index => $meta_key) {
+            if (!isset($row[$index])) {
+                continue;
+            }
+            $val = $row[$index];
+            if ($val === '') {
+                if ($delete) {
+                    delete_post_meta($post_id, $meta_key);
+                }
+                continue;
+            }
+            if (strpos($val, '|') !== false) {
+                $val = array_map('sanitize_text_field', explode('|', $val));
+            } else {
+                $val = sanitize_text_field($val);
+            }
+            update_post_meta($post_id, $meta_key, $val);
+        }
+    }
+    fclose($handle);
 }


### PR DESCRIPTION
## Summary
- bump plugin version to 1.4.0
- add import option for deleting blank values
- implement CSV export/import across all meta keys
- improve README feature section

## Testing
- `php -l seo-bulk-meta-editor.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b13160648324bde3bbc79d2610cf