### PR TITLE
Improve CSV tools and settings banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # Yoast SEO Bulk Meta Editor
 
-## v1.3.0 → v1.4.0
-
 Yoast SEO Bulk Meta Editor is a small WordPress plugin that adds a dedicated admin page for managing Yoast SEO metadata in bulk. It displays the title, meta description and focus keyword for each post, page and any public custom post type in a sortable table so you can update multiple entries quickly.
 
 ## Features
 
 ### Free
-- View all Yoast SEO meta titles, descriptions and keywords in one place
-- Edit meta fields inline and save all changes at once via AJAX
-- Responsive table with "Load More" support for large datasets
+- View all Yoast SEO meta titles, descriptions, keywords and more in one place
+- Edit fields inline with character counters and save via AJAX
+- Undo your last change if needed
+- Filter results by search, post type and category
 - Choose which post types and table columns are included from the plugin's **Settings** page
-- The post type filter dropdown only lists the post types selected in **Settings**
+- Responsive table with "Load More" support for large datasets
 - Requires the [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/) plugin to be installed and active
 
 ### Premium
 - CSV Meta Tools (PRO) for fast import/export of metadata
+- Optional dry run mode to preview changes before importing
 
 ## Installation
 

--- a/css/style.css
+++ b/css/style.css
@@ -100,7 +100,7 @@
     text-align: left;
 }
 
-.ybme-upsell {
+.ybme-banner {
     border: 2px solid #ffba00;
     background: linear-gradient(135deg, #fffbe5, #ffffff);
     padding: 20px;
@@ -110,11 +110,26 @@
     border-radius: 6px;
 }
 
-.ybme-upsell p {
-    margin: 8px 0;
+.ybme-banner h2 {
+    margin-top: 0;
+    margin-bottom: 10px;
 }
 
-.ybme-upsell-subtext {
-    margin-top: 12px;
-    font-size: 14px;
+.ybme-banner ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.ybme-banner li {
+    position: relative;
+    padding-left: 20px;
+    margin: 5px 0;
+}
+
+.ybme-banner li:before {
+    content: "\2713";
+    position: absolute;
+    left: 0;
+    color: #4CAF50;
 }


### PR DESCRIPTION
## Summary
- allow CSV import dry run previews
- restyle upsell banner and remove PRO text
- document new features in README

## Testing
- `php -l seo-bulk-meta-editor.php` *(fails: command not found)*
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_6849bbc2c7048324a4cabe24eca6c269