### PR TITLE
Add configurable rows per page setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Yoast SEO Bulk Meta Editor is a small WordPress plugin that adds a dedicated adm
 - Filter rows by search text, post type and category.
 - Choose which post types and columns appear from the plugin's **Settings** page.
 - Responsive table with a "Load More" button for large datasets.
+- Set how many rows appear per page (defaults to 20).
 - Requires the [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/) plugin to be active.
 
 ### Premium


### PR DESCRIPTION
## Summary
- introduce a setting for rows per page
- default to 20 rows per page
- use saved setting when loading posts and in AJAX
- document rows-per-page option in README

## Testing
- `php` not available in container

------
https://chatgpt.com/codex/tasks/task_e_6849c19e6b3c832495b9f161074e9234