### PR TITLE
Add WPML language filtering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Yoast SEO Bulk Meta Editor is a small WordPress plugin that adds a dedicated adm
 - Choose which post types and columns appear from the plugin's **Settings** page.
 - Responsive table with a "Load More" button for large datasets.
 - Set how many rows appear per page (defaults to 20).
+- Detects WPML and lets you filter posts by language with flag icons in the table.
 - Requires the [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/) plugin to be active.
 
 ### Premium


### PR DESCRIPTION
## Summary
- integrate WPML detection
- add language flag column and language settings
- filter posts by selected languages in table
- update README with new WPML feature

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c2dbb9a083248e557f86dc959404