### PR TITLE
SEO toolkit expansion: multi-provider, GSC, AI generation, approval workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [ '7.2', '8.2' ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer
+
+      - name: PHP syntax check
+        run: |
+          find . -path ./vendor -prune -o -name '*.php' -print0 \
+            | xargs -0 -n1 -P4 php -l
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: PHP_CodeSniffer
+        run: composer run-script lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor/
+/node_modules/
+composer.lock
+.DS_Store
+.phpcs.cache

--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ Yoast SEO Bulk Meta Editor is a WordPress plugin that adds a dedicated admin pag
 - **Per‑row SEO health score** — a traffic‑light dot flags missing titles/descriptions/keywords and length problems, with details on hover.
 - **"Show only problems" filter** — instantly narrow the table to rows that need attention (or just the critical ones).
 - **Bulk find & replace** — search and replace across meta titles, descriptions or keywords for every matching post, with a preview of affected rows before you apply. Supports case sensitivity, regular expressions and template variables (`%%title%%`, `%%sitename%%`, `%%sep%%`).
+- **Site-wide SEO audit** — a dashboard summarising your whole site: score distribution, missing/over/under-length fields by post type, and duplicate meta titles/descriptions across posts, with one-click jumps into the editor or straight to a post.
+- **Google Search Console metrics** — connect a property and show clicks, impressions, CTR and average position per URL as optional editor columns, to prioritise the pages worth rewriting.
+- **AI meta generation** — draft meta titles and descriptions from page content with your own Claude or OpenAI key, per row or in bulk, always as a preview you approve before saving.
 
 ### Safety & history
 - **Change history / audit log** — every edit (single, undo, revert or bulk) is recorded to the database with the old value, new value, user and timestamp.
 - **One‑click revert** — roll any logged change back to its previous value from the **History** page.
+- **Draft & scheduled changes** — submit edits for review instead of saving directly; an administrator approves, rejects or schedules them, and scheduled changes apply automatically at the chosen time.
 
 ### Security
 - All AJAX actions are protected with nonces and capability checks.
@@ -33,7 +37,7 @@ Yoast SEO Bulk Meta Editor is a WordPress plugin that adds a dedicated admin pag
 - All values are escaped on output and sanitized per field on save.
 
 ### Requirements
-- Requires the [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/) plugin to be active.
+- Requires one supported SEO plugin to be active: [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/), [Rank Math](https://wordpress.org/plugins/seo-by-rank-math/) or [SEOPress](https://wordpress.org/plugins/wp-seopress/). (All in One SEO is not supported — it stores data in a custom table rather than post meta.)
 
 ## Installation
 
@@ -51,6 +55,46 @@ Yoast SEO Bulk Meta Editor is a WordPress plugin that adds a dedicated admin pag
 6. Use **Yoast Bulk Meta Editor → Settings** to choose which post types and columns are shown in the table
 
 ## Changelog
+
+### 1.12.0
+- **New:** AI-assisted meta generation. With your own Claude (Anthropic) or OpenAI API key, a per-row **Generate** button drafts a meta title and description from the post's content; an **AI: fill problem rows** button does the same in bulk for visible rows that need attention.
+- **New:** Generated values are inserted as unsaved, highlighted edits so you always review them before saving (or submitting for review) — nothing is written automatically.
+- **New:** An **AI Assistant** settings page to choose the provider, enter the API key and optionally set the model.
+
+### 1.11.0
+- **New:** Draft & scheduled changes with an approval workflow. A **Submit for Review** button queues your edits as drafts (with an optional future apply time) instead of saving directly.
+- **New:** A **Pending Changes** admin page where administrators approve, reject, apply-now or cancel drafts; approved drafts with a future time are applied automatically by WP-Cron. Every applied draft is validated and logged to the change history like a direct save.
+- **Dev:** Added `ybme_install_tables`, `ybme_editor_actions` and `ybme_editor_js_vars` extension hooks.
+
+### 1.10.0
+- **New:** Google Search Console integration. Connect a property over OAuth and add optional **Clicks / Impressions / CTR / Position** columns (last ~28 days) to the editor, so you can prioritise rewriting metas on high-impression, low-CTR pages.
+- **New:** A **Search Console** admin page to enter credentials, connect/disconnect, choose the property and refresh data; metrics also refresh daily via WP-Cron and are cached.
+- **Dev:** Introduced an `includes/` module layer and two extension filters (`ybme_available_columns`, `ybme_render_column_cell`) so read-only columns can be added without touching the core editor.
+
+### 1.9.0
+- **New:** Multi-plugin support. The editor, audit and find & replace now work with **Rank Math** and **SEOPress** in addition to **Yoast SEO**, via a provider abstraction over each plugin's meta keys.
+- **New:** The active SEO plugin is auto-detected (Yoast → Rank Math → SEOPress priority), or you can pick one explicitly on the **Settings** page.
+- **Change:** The plugin now requires *any* one of the supported SEO plugins to be active (previously Yoast specifically). Admin notices, the activation check and all write guards were updated accordingly.
+- **Note:** All in One SEO stores its data in a custom table rather than post meta, so it is not supported by this release.
+
+### 1.8.0
+- **New:** Site-wide **SEO Audit** dashboard (new **Audit** submenu). Shows a good/needs-work/critical score distribution, a per-issue breakdown (missing and over/under-length titles and descriptions, missing keywords), a per-post-type breakdown, and cross-post **duplicate meta title/description** detection with direct edit links.
+- **New:** Audit cards deep-link into the editor with the SEO filter pre-applied; results are cached for 10 minutes and refresh automatically whenever a meta value changes (or on demand via the **Refresh** button).
+
+### 1.7.0
+- **Improvement:** "Save Changes" now saves every edit in a single AJAX request with one summary notification, instead of one request (and one toast) per field.
+- **Improvement:** The edit queue is cleared after a successful save, so pressing Save twice no longer re-submits the same edits.
+- **New:** Unsaved-changes guard — the browser warns before you navigate away with pending edits, and edited cells are highlighted until saved.
+- **Fix:** Settings registration is now hooked on `admin_init` at the top level rather than from inside the `admin_menu` callback.
+- **Dev:** Added Composer config, PHP_CodeSniffer (WordPress Coding Standards) ruleset and a GitHub Actions lint workflow.
+
+### 1.6.1
+- **Security:** All settings (post types, columns, roles, rows-per-page, languages, license key) are now sanitized and validated on save against known-good values.
+- **Security:** Rows-per-page is clamped (1–200) so the editor can no longer be made to query thousands of posts in a single request.
+- **Security:** Bulk find & replace rejects over-long find/replace input to limit exposure to catastrophic-backtracking (ReDoS) patterns.
+- **Security:** Added directory-listing guards (`index.php`) to the plugin folders.
+- **New:** Uninstall cleanup (`uninstall.php`) removes the plugin's options, custom capability and history table when the plugin is deleted.
+- **New:** Runtime Yoast SEO check — shows an admin notice and blocks writes when Yoast is inactive, instead of silently writing orphaned meta.
 
 ### 1.6.0
 - **New:** Live Google (SERP) preview with desktop/mobile layouts that updates while you type.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "nomad-developer/seo-bulk-meta-editor",
+    "description": "Bulk-edit Yoast SEO meta titles, descriptions and keywords from one dashboard.",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name": "Costin Botez",
+            "homepage": "https://nomad-developer.co.uk"
+        }
+    ],
+    "require": {
+        "php": ">=7.2"
+    },
+    "require-dev": {
+        "squizlabs/php_codesniffer": "^3.9",
+        "wp-coding-standards/wpcs": "^3.1",
+        "phpcompatibility/phpcompatibility-wp": "^2.1"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
+    "scripts": {
+        "lint": "phpcs",
+        "lint:fix": "phpcbf"
+    }
+}

--- a/css/index.php
+++ b/css/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/css/style.css
+++ b/css/style.css
@@ -20,6 +20,12 @@
     cursor: pointer;
 }
 
+/* Cells with queued, unsaved edits. */
+.editable.ybme-dirty {
+    background-color: #fff6dd;
+    box-shadow: inset 3px 0 0 #ffb900;
+}
+
 /* Notification styling */
 #notification {
     margin-bottom: 20px;
@@ -271,3 +277,57 @@
 }
 
 .ybme-fr-error { color: #dc3232; }
+
+/* SEO audit dashboard */
+.ybme-audit-cards {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    margin: 16px 0 24px;
+}
+
+.ybme-audit-card {
+    flex: 1 1 140px;
+    min-width: 140px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 18px 12px;
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-top: 4px solid #c3c4c7;
+    border-radius: 8px;
+    text-decoration: none;
+    color: #1d2327;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+
+a.ybme-audit-card:hover {
+    box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+
+.ybme-audit-card.is-good { border-top-color: #46b450; }
+.ybme-audit-card.is-warn { border-top-color: #ffb900; }
+.ybme-audit-card.is-bad  { border-top-color: #dc3232; }
+
+.ybme-audit-num {
+    font-size: 30px;
+    font-weight: 600;
+    line-height: 1;
+}
+
+.ybme-audit-cap {
+    margin-top: 6px;
+    font-size: 13px;
+    color: #646970;
+    text-transform: uppercase;
+    letter-spacing: .03em;
+}
+
+/* Search Console metric columns */
+td.ybme-gsc {
+    text-align: right;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}

--- a/includes/ai.php
+++ b/includes/ai.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * AI-assisted meta generation.
+ *
+ * Drafts a meta title and description for a post from its content using the
+ * user's own Claude (Anthropic) or OpenAI API key. Results are never written
+ * directly: a per-row "Generate" button (and an optional bulk action for
+ * visible problem rows) fills the editor cells as unsaved edits that the user
+ * reviews and then saves or submits for review.
+ *
+ * The API key is sensitive and is stored in an option; the settings page is
+ * gated on `manage_options`. Post content is sent to the configured provider,
+ * which is the point of the feature — configuring a key is opt-in.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function ybme_ai_provider() {
+    $p = get_option('ybme_ai_provider', 'claude');
+    return in_array($p, array('claude', 'openai'), true) ? $p : 'claude';
+}
+
+function ybme_ai_key() {
+    return trim((string) get_option('ybme_ai_key', ''));
+}
+
+function ybme_ai_default_model($provider) {
+    return $provider === 'openai' ? 'gpt-4o-mini' : 'claude-sonnet-5';
+}
+
+function ybme_ai_model() {
+    $m = trim((string) get_option('ybme_ai_model', ''));
+    return $m !== '' ? $m : ybme_ai_default_model(ybme_ai_provider());
+}
+
+function ybme_ai_configured() {
+    return ybme_ai_key() !== '';
+}
+
+/* -------------------------------------------------------------------------
+ * Generation
+ * ---------------------------------------------------------------------- */
+
+// Tidy a single line of model output into a storable meta value.
+function ybme_ai_clean($value) {
+    $value = wp_strip_all_tags((string) $value);
+    $value = trim(preg_replace('/\s+/', ' ', $value));
+    return sanitize_text_field($value);
+}
+
+// Pull a JSON object out of a model response that may include stray prose.
+function ybme_ai_parse_json($text) {
+    $data = json_decode($text, true);
+    if (is_array($data)) {
+        return $data;
+    }
+    if (preg_match('/\{.*\}/s', $text, $m)) {
+        $data = json_decode($m[0], true);
+        if (is_array($data)) {
+            return $data;
+        }
+    }
+    return null;
+}
+
+/**
+ * Generate a meta title + description for a post. Returns
+ * array('title' => ..., 'description' => ...) or a WP_Error.
+ */
+function ybme_ai_generate_meta($post_id) {
+    $post = get_post($post_id);
+    if (!$post) {
+        return new WP_Error('no_post', __('Post not found.', YBME_TEXT_DOMAIN));
+    }
+
+    $content = wp_strip_all_tags($post->post_content);
+    $content = trim(preg_replace('/\s+/', ' ', $content));
+    $content = function_exists('mb_substr') ? mb_substr($content, 0, 1500) : substr($content, 0, 1500);
+
+    $prompt  = "You are an SEO copywriter. Write an SEO meta title and meta description for the web page below.\n";
+    $prompt .= "Rules:\n";
+    $prompt .= "- Meta title: at most 60 characters, compelling, include the main topic.\n";
+    $prompt .= "- Meta description: 140-155 characters, active voice, encourages the click, no clickbait.\n";
+    $prompt .= "- Write in the same language as the content.\n";
+    $prompt .= "- Return ONLY a JSON object of the form {\"title\": \"...\", \"description\": \"...\"} with no extra text.\n\n";
+    $prompt .= 'Page title: ' . $post->post_title . "\n";
+    $prompt .= 'URL: ' . get_permalink($post_id) . "\n";
+    $prompt .= "Content:\n" . $content . "\n";
+
+    $text = ybme_ai_call($prompt);
+    if (is_wp_error($text)) {
+        return $text;
+    }
+
+    $data = ybme_ai_parse_json($text);
+    if (!$data || (empty($data['title']) && empty($data['description']))) {
+        return new WP_Error('parse', __('Could not read the AI response. Try again.', YBME_TEXT_DOMAIN));
+    }
+
+    return array(
+        'title'       => isset($data['title']) ? ybme_ai_clean($data['title']) : '',
+        'description' => isset($data['description']) ? ybme_ai_clean($data['description']) : '',
+    );
+}
+
+// Dispatch a prompt to the configured provider. Returns text or WP_Error.
+function ybme_ai_call($prompt) {
+    if (!ybme_ai_configured()) {
+        return new WP_Error('not_configured', __('AI is not configured.', YBME_TEXT_DOMAIN));
+    }
+    return ybme_ai_provider() === 'openai'
+        ? ybme_ai_call_openai($prompt)
+        : ybme_ai_call_claude($prompt);
+}
+
+function ybme_ai_call_claude($prompt) {
+    $resp = wp_remote_post('https://api.anthropic.com/v1/messages', array(
+        'timeout' => 45,
+        'headers' => array(
+            'x-api-key'         => ybme_ai_key(),
+            'anthropic-version' => '2023-06-01',
+            'content-type'      => 'application/json',
+        ),
+        'body'    => wp_json_encode(array(
+            'model'      => ybme_ai_model(),
+            'max_tokens' => 400,
+            'messages'   => array(array('role' => 'user', 'content' => $prompt)),
+        )),
+    ));
+    if (is_wp_error($resp)) {
+        return $resp;
+    }
+    $code = wp_remote_retrieve_response_code($resp);
+    $body = json_decode(wp_remote_retrieve_body($resp), true);
+    if ($code !== 200) {
+        $msg = isset($body['error']['message']) ? $body['error']['message'] : sprintf(__('API error (%d).', YBME_TEXT_DOMAIN), $code);
+        return new WP_Error('api', $msg);
+    }
+    if (empty($body['content'][0]['text'])) {
+        return new WP_Error('empty', __('Empty AI response.', YBME_TEXT_DOMAIN));
+    }
+    return $body['content'][0]['text'];
+}
+
+function ybme_ai_call_openai($prompt) {
+    $resp = wp_remote_post('https://api.openai.com/v1/chat/completions', array(
+        'timeout' => 45,
+        'headers' => array(
+            'Authorization' => 'Bearer ' . ybme_ai_key(),
+            'Content-Type'  => 'application/json',
+        ),
+        'body'    => wp_json_encode(array(
+            'model'       => ybme_ai_model(),
+            'max_tokens'  => 400,
+            'temperature' => 0.7,
+            'messages'    => array(array('role' => 'user', 'content' => $prompt)),
+        )),
+    ));
+    if (is_wp_error($resp)) {
+        return $resp;
+    }
+    $code = wp_remote_retrieve_response_code($resp);
+    $body = json_decode(wp_remote_retrieve_body($resp), true);
+    if ($code !== 200) {
+        $msg = isset($body['error']['message']) ? $body['error']['message'] : sprintf(__('API error (%d).', YBME_TEXT_DOMAIN), $code);
+        return new WP_Error('api', $msg);
+    }
+    if (empty($body['choices'][0]['message']['content'])) {
+        return new WP_Error('empty', __('Empty AI response.', YBME_TEXT_DOMAIN));
+    }
+    return $body['choices'][0]['message']['content'];
+}
+
+/* -------------------------------------------------------------------------
+ * AJAX
+ * ---------------------------------------------------------------------- */
+
+add_action('wp_ajax_ybme_ai_generate', 'ybme_ai_generate');
+function ybme_ai_generate() {
+    check_ajax_referer(YBME_NONCE_ACTION, 'nonce');
+    if (!current_user_can(YBME_CAPABILITY)) {
+        wp_send_json_error();
+    }
+    if (!ybme_ai_configured()) {
+        wp_send_json_error(array('message' => __('AI is not configured.', YBME_TEXT_DOMAIN)));
+    }
+    $post_id = isset($_POST['post_id']) ? intval($_POST['post_id']) : 0;
+    if ($post_id <= 0 || !current_user_can('edit_post', $post_id)) {
+        wp_send_json_error();
+    }
+    $res = ybme_ai_generate_meta($post_id);
+    if (is_wp_error($res)) {
+        wp_send_json_error(array('message' => $res->get_error_message()));
+    }
+    wp_send_json_success($res);
+}
+
+/* -------------------------------------------------------------------------
+ * Editor integration
+ * ---------------------------------------------------------------------- */
+
+add_filter('ybme_available_columns', 'ybme_ai_register_column');
+function ybme_ai_register_column($cols) {
+    if (ybme_ai_configured()) {
+        $cols['ai_tools'] = array('label' => __('AI', YBME_TEXT_DOMAIN));
+    }
+    return $cols;
+}
+
+add_filter('ybme_render_column_cell', 'ybme_ai_render_cell', 10, 4);
+function ybme_ai_render_cell($cell, $col, $post_id, $permalink) {
+    if ($col !== 'ai_tools') {
+        return $cell;
+    }
+    return '<td><button type="button" class="button ybme-ai-generate">' . esc_html__('Generate', YBME_TEXT_DOMAIN) . '</button></td>';
+}
+
+add_action('ybme_editor_actions', 'ybme_ai_bulk_button');
+function ybme_ai_bulk_button() {
+    if (!ybme_ai_configured()) {
+        return;
+    }
+    echo '<button type="button" id="ybme-ai-bulk" class="button" style="padding:10px 20px;margin-right:10px;">' . esc_html__('AI: fill problem rows', YBME_TEXT_DOMAIN) . '</button>';
+}
+
+add_filter('ybme_editor_js_vars', 'ybme_ai_js_vars');
+function ybme_ai_js_vars($vars) {
+    if (!ybme_ai_configured()) {
+        return $vars;
+    }
+    $vars['ai_enabled'] = true;
+    $vars['i18n']['ai_generate']    = __('Generate', YBME_TEXT_DOMAIN);
+    $vars['i18n']['ai_generating']  = __('Generating…', YBME_TEXT_DOMAIN);
+    $vars['i18n']['ai_done']        = __('Done', YBME_TEXT_DOMAIN);
+    $vars['i18n']['ai_failed']      = __('AI generation failed', YBME_TEXT_DOMAIN);
+    $vars['i18n']['ai_no_rows']     = __('No problem rows are visible.', YBME_TEXT_DOMAIN);
+    $vars['i18n']['ai_bulk_confirm'] = __('Generate meta for up to %d visible problem rows? This calls the AI once per row.', YBME_TEXT_DOMAIN);
+    $vars['i18n']['ai_bulk_done']   = __('Generated %d row(s). Review, then Save.', YBME_TEXT_DOMAIN);
+    return $vars;
+}
+
+/* -------------------------------------------------------------------------
+ * Settings page
+ * ---------------------------------------------------------------------- */
+
+// Priority 20 so the parent menu (registered at the default priority) exists.
+add_action('admin_menu', 'ybme_ai_menu', 20);
+function ybme_ai_menu() {
+    add_submenu_page(
+        'yoast-bulk-meta-editor',
+        __('AI Assistant', YBME_TEXT_DOMAIN),
+        __('AI Assistant', YBME_TEXT_DOMAIN),
+        'manage_options',
+        'yoast-bulk-meta-editor-ai',
+        'ybme_ai_page'
+    );
+}
+
+add_action('admin_init', 'ybme_ai_register_settings');
+function ybme_ai_register_settings() {
+    register_setting('ybme-ai-settings-group', 'ybme_ai_provider', array('sanitize_callback' => 'ybme_ai_sanitize_provider'));
+    register_setting('ybme-ai-settings-group', 'ybme_ai_key', array('sanitize_callback' => 'sanitize_text_field'));
+    register_setting('ybme-ai-settings-group', 'ybme_ai_model', array('sanitize_callback' => 'sanitize_text_field'));
+}
+
+function ybme_ai_sanitize_provider($value) {
+    return in_array($value, array('claude', 'openai'), true) ? $value : 'claude';
+}
+
+function ybme_ai_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die();
+    }
+    $provider = ybme_ai_provider();
+    echo '<div class="wrap">';
+    echo '<h1>' . esc_html__('AI Assistant', YBME_TEXT_DOMAIN) . '</h1>';
+    echo '<p class="description">' . esc_html__('Generate meta titles and descriptions from page content. Your API key is stored on this site and page content is sent to the selected provider when you click Generate.', YBME_TEXT_DOMAIN) . '</p>';
+
+    echo '<form method="post" action="options.php">';
+    settings_fields('ybme-ai-settings-group');
+    echo '<table class="form-table"><tbody>';
+
+    echo '<tr><th scope="row"><label for="ybme_ai_provider">' . esc_html__('Provider', YBME_TEXT_DOMAIN) . '</label></th><td>';
+    echo '<select id="ybme_ai_provider" name="ybme_ai_provider">';
+    echo '<option value="claude" ' . selected($provider, 'claude', false) . '>' . esc_html__('Claude (Anthropic)', YBME_TEXT_DOMAIN) . '</option>';
+    echo '<option value="openai" ' . selected($provider, 'openai', false) . '>' . esc_html__('OpenAI', YBME_TEXT_DOMAIN) . '</option>';
+    echo '</select></td></tr>';
+
+    echo '<tr><th scope="row"><label for="ybme_ai_key">' . esc_html__('API key', YBME_TEXT_DOMAIN) . '</label></th>';
+    echo '<td><input type="password" class="regular-text" id="ybme_ai_key" name="ybme_ai_key" value="' . esc_attr(ybme_ai_key()) . '" autocomplete="off" /></td></tr>';
+
+    echo '<tr><th scope="row"><label for="ybme_ai_model">' . esc_html__('Model', YBME_TEXT_DOMAIN) . '</label></th>';
+    echo '<td><input type="text" class="regular-text" id="ybme_ai_model" name="ybme_ai_model" value="' . esc_attr((string) get_option('ybme_ai_model', '')) . '" placeholder="' . esc_attr(ybme_ai_default_model($provider)) . '" />';
+    echo '<p class="description">' . sprintf(
+        /* translators: 1: Claude default model, 2: OpenAI default model */
+        esc_html__('Leave blank for the default (%1$s for Claude, %2$s for OpenAI).', YBME_TEXT_DOMAIN),
+        esc_html(ybme_ai_default_model('claude')),
+        esc_html(ybme_ai_default_model('openai'))
+    ) . '</p></td></tr>';
+
+    echo '</tbody></table>';
+    submit_button();
+    echo '</form>';
+
+    if (ybme_ai_configured()) {
+        echo '<p>' . esc_html__('Enable the "AI" column on the Settings page to show a Generate button per row.', YBME_TEXT_DOMAIN) . '</p>';
+    }
+    echo '</div>';
+}

--- a/includes/gsc.php
+++ b/includes/gsc.php
@@ -1,0 +1,528 @@
+<?php
+/**
+ * Google Search Console integration.
+ *
+ * Connects a Search Console property over OAuth2 (no bundled Google client
+ * library — just wp_remote_* calls) and surfaces clicks / impressions / CTR /
+ * average position per URL as optional, read-only columns in the editor so
+ * users can prioritise the pages that get impressions but few clicks.
+ *
+ * Credentials and tokens live in options. They are sensitive: the client
+ * secret and refresh token grant read access to the site's Search Console
+ * data, so this page is gated on `manage_options`.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('YBME_GSC_SCOPE', 'https://www.googleapis.com/auth/webmasters.readonly');
+define('YBME_GSC_AUTH_ENDPOINT', 'https://accounts.google.com/o/oauth2/v2/auth');
+define('YBME_GSC_TOKEN_ENDPOINT', 'https://oauth2.googleapis.com/token');
+define('YBME_GSC_API_BASE', 'https://www.googleapis.com/webmasters/v3');
+define('YBME_GSC_DATA_TRANSIENT', 'ybme_gsc_data');
+define('YBME_GSC_CRON_HOOK', 'ybme_gsc_refresh_cron');
+
+/* -------------------------------------------------------------------------
+ * State helpers
+ * ---------------------------------------------------------------------- */
+
+function ybme_gsc_client_id() {
+    return trim((string) get_option('ybme_gsc_client_id', ''));
+}
+
+function ybme_gsc_client_secret() {
+    return trim((string) get_option('ybme_gsc_client_secret', ''));
+}
+
+// OAuth credentials have been entered.
+function ybme_gsc_configured() {
+    return ybme_gsc_client_id() !== '' && ybme_gsc_client_secret() !== '';
+}
+
+function ybme_gsc_get_tokens() {
+    $t = get_option('ybme_gsc_tokens', array());
+    return is_array($t) ? $t : array();
+}
+
+function ybme_gsc_save_tokens($tokens) {
+    update_option('ybme_gsc_tokens', $tokens, false);
+}
+
+function ybme_gsc_delete_tokens() {
+    delete_option('ybme_gsc_tokens');
+    delete_option('ybme_gsc_site');
+    delete_transient(YBME_GSC_DATA_TRANSIENT);
+}
+
+// A refresh token has been stored, i.e. the property is connected.
+function ybme_gsc_connected() {
+    $t = ybme_gsc_get_tokens();
+    return !empty($t['refresh_token']);
+}
+
+function ybme_gsc_selected_site() {
+    return (string) get_option('ybme_gsc_site', '');
+}
+
+// The exact redirect URI that must be registered in the Google Cloud console.
+function ybme_gsc_redirect_uri() {
+    return admin_url('admin.php?page=yoast-bulk-meta-editor-gsc');
+}
+
+/* -------------------------------------------------------------------------
+ * OAuth2
+ * ---------------------------------------------------------------------- */
+
+function ybme_gsc_auth_url() {
+    $args = array(
+        'client_id'     => ybme_gsc_client_id(),
+        'redirect_uri'  => ybme_gsc_redirect_uri(),
+        'response_type' => 'code',
+        'scope'         => YBME_GSC_SCOPE,
+        'access_type'   => 'offline',
+        'prompt'        => 'consent',
+        'state'         => wp_create_nonce('ybme_gsc_oauth'),
+    );
+    return YBME_GSC_AUTH_ENDPOINT . '?' . http_build_query($args);
+}
+
+/**
+ * Exchange an authorization code for tokens. Returns true on success.
+ */
+function ybme_gsc_exchange_code($code) {
+    $resp = wp_remote_post(YBME_GSC_TOKEN_ENDPOINT, array(
+        'timeout' => 20,
+        'body'    => array(
+            'code'          => $code,
+            'client_id'     => ybme_gsc_client_id(),
+            'client_secret' => ybme_gsc_client_secret(),
+            'redirect_uri'  => ybme_gsc_redirect_uri(),
+            'grant_type'    => 'authorization_code',
+        ),
+    ));
+    if (is_wp_error($resp) || wp_remote_retrieve_response_code($resp) !== 200) {
+        return false;
+    }
+    $data = json_decode(wp_remote_retrieve_body($resp), true);
+    if (!is_array($data) || empty($data['access_token'])) {
+        return false;
+    }
+    // Google only returns the refresh token on the first consent; keep any
+    // existing one if this response omits it.
+    $existing = ybme_gsc_get_tokens();
+    ybme_gsc_save_tokens(array(
+        'access_token'  => $data['access_token'],
+        'refresh_token' => !empty($data['refresh_token']) ? $data['refresh_token'] : (isset($existing['refresh_token']) ? $existing['refresh_token'] : ''),
+        'expires_at'    => time() + (isset($data['expires_in']) ? intval($data['expires_in']) : 3600),
+    ));
+    return true;
+}
+
+/**
+ * A valid access token, refreshing it if expired. Empty string on failure.
+ */
+function ybme_gsc_access_token() {
+    $t = ybme_gsc_get_tokens();
+    if (empty($t['refresh_token'])) {
+        return '';
+    }
+    if (!empty($t['access_token']) && isset($t['expires_at']) && $t['expires_at'] > (time() + 60)) {
+        return $t['access_token'];
+    }
+
+    $resp = wp_remote_post(YBME_GSC_TOKEN_ENDPOINT, array(
+        'timeout' => 20,
+        'body'    => array(
+            'client_id'     => ybme_gsc_client_id(),
+            'client_secret' => ybme_gsc_client_secret(),
+            'refresh_token' => $t['refresh_token'],
+            'grant_type'    => 'refresh_token',
+        ),
+    ));
+    if (is_wp_error($resp) || wp_remote_retrieve_response_code($resp) !== 200) {
+        return '';
+    }
+    $data = json_decode(wp_remote_retrieve_body($resp), true);
+    if (!is_array($data) || empty($data['access_token'])) {
+        return '';
+    }
+    $t['access_token'] = $data['access_token'];
+    $t['expires_at']   = time() + (isset($data['expires_in']) ? intval($data['expires_in']) : 3600);
+    ybme_gsc_save_tokens($t);
+    return $t['access_token'];
+}
+
+/* -------------------------------------------------------------------------
+ * API calls
+ * ---------------------------------------------------------------------- */
+
+function ybme_gsc_api_get($path) {
+    $token = ybme_gsc_access_token();
+    if ($token === '') {
+        return null;
+    }
+    $resp = wp_remote_get(YBME_GSC_API_BASE . $path, array(
+        'timeout' => 20,
+        'headers' => array('Authorization' => 'Bearer ' . $token),
+    ));
+    if (is_wp_error($resp) || wp_remote_retrieve_response_code($resp) !== 200) {
+        return null;
+    }
+    return json_decode(wp_remote_retrieve_body($resp), true);
+}
+
+function ybme_gsc_api_post($path, $body) {
+    $token = ybme_gsc_access_token();
+    if ($token === '') {
+        return null;
+    }
+    $resp = wp_remote_post(YBME_GSC_API_BASE . $path, array(
+        'timeout' => 30,
+        'headers' => array(
+            'Authorization' => 'Bearer ' . $token,
+            'Content-Type'  => 'application/json',
+        ),
+        'body'    => wp_json_encode($body),
+    ));
+    if (is_wp_error($resp) || wp_remote_retrieve_response_code($resp) !== 200) {
+        return null;
+    }
+    return json_decode(wp_remote_retrieve_body($resp), true);
+}
+
+// The Search Console properties this account can read.
+function ybme_gsc_list_sites() {
+    $data = ybme_gsc_api_get('/sites');
+    if (!is_array($data) || empty($data['siteEntry'])) {
+        return array();
+    }
+    $sites = array();
+    foreach ($data['siteEntry'] as $entry) {
+        if (!empty($entry['siteUrl'])) {
+            $sites[] = $entry['siteUrl'];
+        }
+    }
+    return $sites;
+}
+
+/* -------------------------------------------------------------------------
+ * Metrics
+ * ---------------------------------------------------------------------- */
+
+/**
+ * Normalise a URL for matching GSC rows against post permalinks: drop the
+ * scheme, lowercase the host (but not the path), and trim a trailing slash.
+ */
+function ybme_gsc_normalize_url($url) {
+    $url = preg_replace('#^https?://#i', '', trim((string) $url));
+    $url = rtrim($url, '/');
+    $slash = strpos($url, '/');
+    if ($slash === false) {
+        return strtolower($url);
+    }
+    return strtolower(substr($url, 0, $slash)) . substr($url, $slash);
+}
+
+/**
+ * Query Search Console for per-page metrics over the last ~28 days and cache
+ * a normalized-URL => metrics map. Returns the map (possibly empty).
+ */
+function ybme_gsc_fetch_metrics($force = false) {
+    if (!$force) {
+        $cached = get_transient(YBME_GSC_DATA_TRANSIENT);
+        if (is_array($cached)) {
+            return $cached;
+        }
+    }
+
+    $site = ybme_gsc_selected_site();
+    if ($site === '' || !ybme_gsc_connected()) {
+        return array();
+    }
+
+    // GSC data lags a couple of days; end the window three days back.
+    $end   = gmdate('Y-m-d', time() - 3 * DAY_IN_SECONDS);
+    $start = gmdate('Y-m-d', time() - 31 * DAY_IN_SECONDS);
+
+    $data = ybme_gsc_api_post('/sites/' . rawurlencode($site) . '/searchAnalytics/query', array(
+        'startDate'  => $start,
+        'endDate'    => $end,
+        'dimensions' => array('page'),
+        'rowLimit'   => 25000,
+    ));
+
+    $map = array();
+    if (is_array($data) && !empty($data['rows'])) {
+        foreach ($data['rows'] as $r) {
+            if (empty($r['keys'][0])) {
+                continue;
+            }
+            $map[ybme_gsc_normalize_url($r['keys'][0])] = array(
+                'clicks'      => isset($r['clicks']) ? (int) round($r['clicks']) : 0,
+                'impressions' => isset($r['impressions']) ? (int) round($r['impressions']) : 0,
+                'ctr'         => isset($r['ctr']) ? (float) $r['ctr'] : 0.0,
+                'position'    => isset($r['position']) ? (float) $r['position'] : 0.0,
+            );
+        }
+    }
+
+    set_transient(YBME_GSC_DATA_TRANSIENT, $map, 12 * HOUR_IN_SECONDS);
+    return $map;
+}
+
+// Memoized read of the cached metrics for the current request (no API call).
+function ybme_gsc_metrics_map() {
+    static $map = null;
+    if ($map === null) {
+        $cached = get_transient(YBME_GSC_DATA_TRANSIENT);
+        $map    = is_array($cached) ? $cached : array();
+    }
+    return $map;
+}
+
+function ybme_gsc_metrics_for_url($url) {
+    $map = ybme_gsc_metrics_map();
+    $key = ybme_gsc_normalize_url($url);
+    return isset($map[$key]) ? $map[$key] : null;
+}
+
+/* -------------------------------------------------------------------------
+ * Editor columns
+ * ---------------------------------------------------------------------- */
+
+function ybme_gsc_columns() {
+    return array(
+        'gsc_clicks'      => __('Clicks', YBME_TEXT_DOMAIN),
+        'gsc_impressions' => __('Impressions', YBME_TEXT_DOMAIN),
+        'gsc_ctr'         => __('CTR', YBME_TEXT_DOMAIN),
+        'gsc_position'    => __('Position', YBME_TEXT_DOMAIN),
+    );
+}
+
+add_filter('ybme_available_columns', 'ybme_gsc_register_columns');
+function ybme_gsc_register_columns($cols) {
+    if (!ybme_gsc_connected()) {
+        return $cols;
+    }
+    foreach (ybme_gsc_columns() as $key => $label) {
+        $cols[$key] = array('label' => $label); // No meta_key: read-only.
+    }
+    return $cols;
+}
+
+add_filter('ybme_render_column_cell', 'ybme_gsc_render_cell', 10, 4);
+function ybme_gsc_render_cell($cell, $col, $post_id, $permalink) {
+    if (!isset(ybme_gsc_columns()[$col])) {
+        return $cell;
+    }
+    $m = ybme_gsc_metrics_for_url($permalink);
+    if (!$m) {
+        return '<td class="ybme-gsc" data-value="-1">&mdash;</td>';
+    }
+    switch ($col) {
+        case 'gsc_clicks':
+            return '<td class="ybme-gsc" data-value="' . esc_attr($m['clicks']) . '">' . esc_html(number_format_i18n($m['clicks'])) . '</td>';
+        case 'gsc_impressions':
+            return '<td class="ybme-gsc" data-value="' . esc_attr($m['impressions']) . '">' . esc_html(number_format_i18n($m['impressions'])) . '</td>';
+        case 'gsc_ctr':
+            $pct = $m['ctr'] * 100;
+            return '<td class="ybme-gsc" data-value="' . esc_attr($pct) . '">' . esc_html(number_format_i18n($pct, 1)) . '%</td>';
+        case 'gsc_position':
+            return '<td class="ybme-gsc" data-value="' . esc_attr($m['position']) . '">' . esc_html(number_format_i18n($m['position'], 1)) . '</td>';
+    }
+    return $cell;
+}
+
+/* -------------------------------------------------------------------------
+ * Admin page, settings, actions
+ * ---------------------------------------------------------------------- */
+
+// Priority 20 so the parent menu (registered at the default priority) exists.
+add_action('admin_menu', 'ybme_gsc_menu', 20);
+function ybme_gsc_menu() {
+    add_submenu_page(
+        'yoast-bulk-meta-editor',
+        __('Search Console', YBME_TEXT_DOMAIN),
+        __('Search Console', YBME_TEXT_DOMAIN),
+        'manage_options',
+        'yoast-bulk-meta-editor-gsc',
+        'ybme_gsc_page'
+    );
+}
+
+add_action('admin_init', 'ybme_gsc_register_settings');
+function ybme_gsc_register_settings() {
+    register_setting('ybme-gsc-settings-group', 'ybme_gsc_client_id', array('sanitize_callback' => 'sanitize_text_field'));
+    register_setting('ybme-gsc-settings-group', 'ybme_gsc_client_secret', array('sanitize_callback' => 'sanitize_text_field'));
+}
+
+// Handle OAuth callback and connect/disconnect/refresh/site actions.
+add_action('admin_init', 'ybme_gsc_handle_actions');
+function ybme_gsc_handle_actions() {
+    if (!isset($_GET['page']) || $_GET['page'] !== 'yoast-bulk-meta-editor-gsc') {
+        return;
+    }
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+    $base = ybme_gsc_redirect_uri();
+
+    // OAuth callback: ?code=...&state=...
+    if (isset($_GET['code'])) {
+        $state = isset($_GET['state']) ? sanitize_text_field(wp_unslash($_GET['state'])) : '';
+        if (!wp_verify_nonce($state, 'ybme_gsc_oauth')) {
+            wp_safe_redirect($base . '&ybme_gsc_status=badstate');
+            exit;
+        }
+        $ok = ybme_gsc_exchange_code(sanitize_text_field(wp_unslash($_GET['code'])));
+        wp_safe_redirect($base . '&ybme_gsc_status=' . ($ok ? 'connected' : 'error'));
+        exit;
+    }
+
+    $action = isset($_GET['ybme_gsc_action']) ? sanitize_key($_GET['ybme_gsc_action']) : '';
+    if ($action === '') {
+        return;
+    }
+    check_admin_referer('ybme_gsc_action');
+
+    if ($action === 'disconnect') {
+        ybme_gsc_delete_tokens();
+        wp_safe_redirect($base . '&ybme_gsc_status=disconnected');
+        exit;
+    }
+    if ($action === 'refresh') {
+        ybme_gsc_fetch_metrics(true);
+        wp_safe_redirect($base . '&ybme_gsc_status=refreshed');
+        exit;
+    }
+    if ($action === 'select_site') {
+        $site = isset($_GET['site']) ? esc_url_raw(wp_unslash($_GET['site'])) : '';
+        // Domain properties look like "sc-domain:example.com" and aren't URLs.
+        if ($site === '' && isset($_GET['site'])) {
+            $site = sanitize_text_field(wp_unslash($_GET['site']));
+        }
+        update_option('ybme_gsc_site', $site);
+        delete_transient(YBME_GSC_DATA_TRANSIENT);
+        wp_safe_redirect($base . '&ybme_gsc_status=site_saved');
+        exit;
+    }
+}
+
+function ybme_gsc_action_url($action) {
+    return wp_nonce_url(ybme_gsc_redirect_uri() . '&ybme_gsc_action=' . $action, 'ybme_gsc_action');
+}
+
+function ybme_gsc_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die();
+    }
+
+    $status = isset($_GET['ybme_gsc_status']) ? sanitize_key($_GET['ybme_gsc_status']) : '';
+    $notices = array(
+        'connected'    => array('updated', __('Connected to Google Search Console.', YBME_TEXT_DOMAIN)),
+        'disconnected' => array('updated', __('Disconnected from Google Search Console.', YBME_TEXT_DOMAIN)),
+        'refreshed'    => array('updated', __('Search Console data refreshed.', YBME_TEXT_DOMAIN)),
+        'site_saved'   => array('updated', __('Property saved.', YBME_TEXT_DOMAIN)),
+        'error'        => array('error', __('Could not connect. Check your credentials and try again.', YBME_TEXT_DOMAIN)),
+        'badstate'     => array('error', __('Security check failed. Please try connecting again.', YBME_TEXT_DOMAIN)),
+    );
+
+    echo '<div class="wrap">';
+    echo '<h1>' . esc_html__('Search Console', YBME_TEXT_DOMAIN) . '</h1>';
+
+    if (isset($notices[$status])) {
+        printf('<div class="notice notice-%s is-dismissible"><p>%s</p></div>', esc_attr($notices[$status][0]), esc_html($notices[$status][1]));
+    }
+
+    // Credentials.
+    echo '<h2>' . esc_html__('Google API credentials', YBME_TEXT_DOMAIN) . '</h2>';
+    echo '<p class="description">' . sprintf(
+        /* translators: %s: the redirect URI to register in Google Cloud */
+        esc_html__('Create an OAuth client (Web application) in Google Cloud with the Search Console API enabled, and add this redirect URI: %s', YBME_TEXT_DOMAIN),
+        '<code>' . esc_html(ybme_gsc_redirect_uri()) . '</code>'
+    ) . '</p>';
+    echo '<form method="post" action="options.php">';
+    settings_fields('ybme-gsc-settings-group');
+    echo '<table class="form-table"><tbody>';
+    echo '<tr><th scope="row"><label for="ybme_gsc_client_id">' . esc_html__('Client ID', YBME_TEXT_DOMAIN) . '</label></th>';
+    echo '<td><input type="text" class="regular-text" id="ybme_gsc_client_id" name="ybme_gsc_client_id" value="' . esc_attr(ybme_gsc_client_id()) . '" autocomplete="off" /></td></tr>';
+    echo '<tr><th scope="row"><label for="ybme_gsc_client_secret">' . esc_html__('Client Secret', YBME_TEXT_DOMAIN) . '</label></th>';
+    echo '<td><input type="password" class="regular-text" id="ybme_gsc_client_secret" name="ybme_gsc_client_secret" value="' . esc_attr(ybme_gsc_client_secret()) . '" autocomplete="off" /></td></tr>';
+    echo '</tbody></table>';
+    submit_button(__('Save credentials', YBME_TEXT_DOMAIN));
+    echo '</form>';
+
+    if (!ybme_gsc_configured()) {
+        echo '<p>' . esc_html__('Enter your credentials above to connect a property.', YBME_TEXT_DOMAIN) . '</p></div>';
+        return;
+    }
+
+    // Connection.
+    echo '<h2>' . esc_html__('Connection', YBME_TEXT_DOMAIN) . '</h2>';
+    if (!ybme_gsc_connected()) {
+        echo '<p><a class="button button-primary" href="' . esc_url(ybme_gsc_auth_url()) . '">' . esc_html__('Connect to Google Search Console', YBME_TEXT_DOMAIN) . '</a></p>';
+        echo '</div>';
+        return;
+    }
+
+    echo '<p>' . esc_html__('Status:', YBME_TEXT_DOMAIN) . ' <strong style="color:#46b450;">' . esc_html__('Connected', YBME_TEXT_DOMAIN) . '</strong> ';
+    echo '<a class="button" href="' . esc_url(ybme_gsc_action_url('disconnect')) . '">' . esc_html__('Disconnect', YBME_TEXT_DOMAIN) . '</a></p>';
+
+    // Property picker.
+    $sites    = ybme_gsc_list_sites();
+    $selected = ybme_gsc_selected_site();
+    echo '<h2>' . esc_html__('Property', YBME_TEXT_DOMAIN) . '</h2>';
+    if (empty($sites)) {
+        echo '<p>' . esc_html__('No Search Console properties were found for this account.', YBME_TEXT_DOMAIN) . '</p>';
+    } else {
+        echo '<form method="get" action="' . esc_url(admin_url('admin.php')) . '">';
+        echo '<input type="hidden" name="page" value="yoast-bulk-meta-editor-gsc" />';
+        echo '<input type="hidden" name="ybme_gsc_action" value="select_site" />';
+        wp_nonce_field('ybme_gsc_action');
+        echo '<select name="site">';
+        foreach ($sites as $site) {
+            echo '<option value="' . esc_attr($site) . '" ' . selected($selected, $site, false) . '>' . esc_html($site) . '</option>';
+        }
+        echo '</select> ';
+        submit_button(__('Use this property', YBME_TEXT_DOMAIN), 'secondary', '', false);
+        echo '</form>';
+    }
+
+    // Data status + manual refresh.
+    if ($selected !== '') {
+        $map = ybme_gsc_metrics_map();
+        echo '<h2>' . esc_html__('Data', YBME_TEXT_DOMAIN) . '</h2>';
+        echo '<p>' . esc_html(sprintf(
+            /* translators: %d: number of URLs with cached metrics */
+            __('Cached metrics for %d URLs (last ~28 days).', YBME_TEXT_DOMAIN),
+            count($map)
+        )) . '</p>';
+        echo '<p><a class="button button-primary" href="' . esc_url(ybme_gsc_action_url('refresh')) . '">' . esc_html__('Refresh data now', YBME_TEXT_DOMAIN) . '</a></p>';
+        echo '<p class="description">' . esc_html__('Enable the Clicks / Impressions / CTR / Position columns on the Settings page to see them in the editor.', YBME_TEXT_DOMAIN) . '</p>';
+    }
+
+    echo '</div>';
+}
+
+/* -------------------------------------------------------------------------
+ * Daily refresh cron
+ * ---------------------------------------------------------------------- */
+
+add_action('init', 'ybme_gsc_schedule_cron');
+function ybme_gsc_schedule_cron() {
+    if (ybme_gsc_connected() && ybme_gsc_selected_site() !== '' && !wp_next_scheduled(YBME_GSC_CRON_HOOK)) {
+        wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', YBME_GSC_CRON_HOOK);
+    }
+}
+
+add_action(YBME_GSC_CRON_HOOK, 'ybme_gsc_cron_refresh');
+function ybme_gsc_cron_refresh() {
+    ybme_gsc_fetch_metrics(true);
+}
+
+// Clear the cron when the plugin is deactivated.
+register_deactivation_hook(YBME_PATH . 'seo-bulk-meta-editor.php', 'ybme_gsc_clear_cron');
+function ybme_gsc_clear_cron() {
+    wp_clear_scheduled_hook(YBME_GSC_CRON_HOOK);
+}

--- a/includes/index.php
+++ b/includes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/includes/pending.php
+++ b/includes/pending.php
@@ -1,0 +1,364 @@
+<?php
+/**
+ * Draft & scheduled changes with an approval workflow.
+ *
+ * Editors (anyone with the plugin's edit capability) can submit meta changes
+ * as drafts instead of saving them directly, optionally requesting a future
+ * apply time. Administrators review the queue and approve or reject each
+ * draft; approving either applies it immediately or schedules it. A cron
+ * applies scheduled drafts when they fall due. Every applied draft goes
+ * through the same validation and history logging as a direct save.
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('YBME_PENDING_CRON_HOOK', 'ybme_pending_cron');
+
+function ybme_pending_table() {
+    global $wpdb;
+    return $wpdb->prefix . 'ybme_pending';
+}
+
+/* -------------------------------------------------------------------------
+ * Schema (created during the shared upgrade routine)
+ * ---------------------------------------------------------------------- */
+
+add_action('ybme_install_tables', 'ybme_install_pending_table');
+function ybme_install_pending_table() {
+    global $wpdb;
+    $table   = ybme_pending_table();
+    $charset = $wpdb->get_charset_collate();
+
+    $sql = "CREATE TABLE {$table} (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        post_id bigint(20) unsigned NOT NULL,
+        meta_key varchar(191) NOT NULL,
+        old_value longtext NULL,
+        new_value longtext NULL,
+        status varchar(20) NOT NULL DEFAULT 'pending',
+        scheduled_for datetime NULL,
+        submitted_by bigint(20) unsigned NOT NULL DEFAULT 0,
+        reviewed_by bigint(20) unsigned NULL,
+        created_at datetime NOT NULL,
+        updated_at datetime NOT NULL,
+        PRIMARY KEY  (id),
+        KEY status (status),
+        KEY scheduled_for (scheduled_for)
+    ) {$charset};";
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta($sql);
+}
+
+// Count drafts still awaiting review (for the menu bubble).
+function ybme_pending_count() {
+    global $wpdb;
+    $table = ybme_pending_table();
+    return (int) $wpdb->get_var("SELECT COUNT(*) FROM {$table} WHERE status = 'pending'");
+}
+
+/* -------------------------------------------------------------------------
+ * Submit drafts from the editor
+ * ---------------------------------------------------------------------- */
+
+add_action('ybme_editor_actions', 'ybme_pending_editor_button');
+function ybme_pending_editor_button() {
+    echo '<button type="button" id="ybme-submit-review" class="button" style="padding:10px 20px;margin-right:10px;">' . esc_html__('Submit for Review…', YBME_TEXT_DOMAIN) . '</button>';
+    echo '<span id="ybme-schedule-wrap" style="display:none;">';
+    echo '<label>' . esc_html__('Apply at:', YBME_TEXT_DOMAIN) . ' <input type="datetime-local" id="ybme-schedule-at" /></label> ';
+    echo '<button type="button" id="ybme-submit-review-go" class="button button-primary">' . esc_html__('Submit', YBME_TEXT_DOMAIN) . '</button>';
+    echo '</span>';
+}
+
+add_filter('ybme_editor_js_vars', 'ybme_pending_js_vars');
+function ybme_pending_js_vars($vars) {
+    $vars['i18n']['submit_none'] = __('No changes to submit', YBME_TEXT_DOMAIN);
+    $vars['i18n']['submit_ok']   = __('%d change(s) submitted for review', YBME_TEXT_DOMAIN);
+    $vars['i18n']['submit_fail'] = __('Failed to submit changes', YBME_TEXT_DOMAIN);
+    return $vars;
+}
+
+add_action('wp_ajax_ybme_pending_submit', 'ybme_pending_submit');
+function ybme_pending_submit() {
+    check_ajax_referer(YBME_NONCE_ACTION, 'nonce');
+    if (!current_user_can(YBME_CAPABILITY)) {
+        wp_send_json_error();
+    }
+    if (!ybme_provider_active()) {
+        wp_send_json_error(array('message' => __('No supported SEO plugin is active.', YBME_TEXT_DOMAIN)));
+    }
+
+    $raw     = isset($_POST['changes']) ? wp_unslash($_POST['changes']) : '';
+    $changes = json_decode($raw, true);
+    if (!is_array($changes) || empty($changes)) {
+        wp_send_json_error(array('message' => __('No changes to submit.', YBME_TEXT_DOMAIN)));
+    }
+
+    // Interpret the optional datetime-local value as site local time.
+    $scheduled = null;
+    if (!empty($_POST['scheduled_for'])) {
+        $input = sanitize_text_field(wp_unslash($_POST['scheduled_for']));
+        $dt    = date_create($input, wp_timezone());
+        if ($dt) {
+            $scheduled = $dt->format('Y-m-d H:i:s');
+        }
+    }
+
+    $allowed = ybme_allowed_meta_keys();
+    $now     = current_time('mysql');
+    $uid     = get_current_user_id();
+    $table   = ybme_pending_table();
+    global $wpdb;
+
+    $queued  = 0;
+    $skipped = 0;
+
+    foreach ($changes as $post_id => $fields) {
+        $post_id = intval($post_id);
+        if ($post_id <= 0 || !is_array($fields)) {
+            $skipped++;
+            continue;
+        }
+        if (!current_user_can('edit_post', $post_id)) {
+            $skipped++;
+            continue;
+        }
+        foreach ($fields as $meta_key => $value) {
+            if (!in_array($meta_key, $allowed, true)) {
+                $skipped++;
+                continue;
+            }
+            $old = get_post_meta($post_id, $meta_key, true);
+            $new = ybme_sanitize_meta_value($meta_key, (string) $value);
+            if ((string) $old === (string) $new) {
+                continue; // Nothing actually changed.
+            }
+            $data = array(
+                'post_id'      => $post_id,
+                'meta_key'     => $meta_key,
+                'old_value'    => $old,
+                'new_value'    => $new,
+                'status'       => 'pending',
+                'submitted_by' => $uid,
+                'created_at'   => $now,
+                'updated_at'   => $now,
+            );
+            if ($scheduled !== null) {
+                $data['scheduled_for'] = $scheduled;
+            }
+            $wpdb->insert($table, $data);
+            $queued++;
+        }
+    }
+
+    wp_send_json_success(array('queued' => $queued, 'skipped' => $skipped));
+}
+
+/* -------------------------------------------------------------------------
+ * Applying a draft
+ * ---------------------------------------------------------------------- */
+
+/**
+ * Write one draft's value to post meta, re-validating at apply time. Returns
+ * true when applied. Re-checks the allow-list and that the ORIGINAL submitter
+ * can still edit the post (there is no current user during cron).
+ */
+function ybme_pending_apply_row($row) {
+    if (!in_array($row->meta_key, ybme_allowed_meta_keys(), true)) {
+        return false;
+    }
+    if (!user_can((int) $row->submitted_by, 'edit_post', (int) $row->post_id)) {
+        return false;
+    }
+    $value   = ybme_sanitize_meta_value($row->meta_key, $row->new_value);
+    $current = get_post_meta($row->post_id, $row->meta_key, true);
+    update_post_meta($row->post_id, $row->meta_key, wp_slash($value));
+    ybme_log_change($row->post_id, $row->meta_key, $current, $value);
+    return true;
+}
+
+/* -------------------------------------------------------------------------
+ * Review actions (approve / reject / apply now / cancel)
+ * ---------------------------------------------------------------------- */
+
+add_action('admin_init', 'ybme_pending_handle_actions');
+function ybme_pending_handle_actions() {
+    if (!isset($_GET['page']) || $_GET['page'] !== 'yoast-bulk-meta-editor-pending') {
+        return;
+    }
+    if (!current_user_can('manage_options')) {
+        return;
+    }
+    $action = isset($_GET['ybme_p_action']) ? sanitize_key($_GET['ybme_p_action']) : '';
+    if ($action === '') {
+        return;
+    }
+    $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+    check_admin_referer('ybme_pending_' . $id);
+
+    global $wpdb;
+    $table = ybme_pending_table();
+    $base  = admin_url('admin.php?page=yoast-bulk-meta-editor-pending');
+    $row   = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE id = %d", $id));
+    if (!$row) {
+        wp_safe_redirect($base);
+        exit;
+    }
+    $now = current_time('mysql');
+    $me  = get_current_user_id();
+
+    if ($action === 'approve') {
+        if (!empty($row->scheduled_for) && $row->scheduled_for > $now) {
+            // Future apply time: schedule it for the cron to pick up.
+            $wpdb->update($table, array('status' => 'scheduled', 'reviewed_by' => $me, 'updated_at' => $now), array('id' => $id));
+        } else {
+            $applied = ybme_pending_apply_row($row);
+            $wpdb->update($table, array('status' => $applied ? 'applied' : 'rejected', 'reviewed_by' => $me, 'updated_at' => $now), array('id' => $id));
+        }
+    } elseif ($action === 'apply') {
+        $applied = ybme_pending_apply_row($row);
+        $wpdb->update($table, array('status' => $applied ? 'applied' : 'rejected', 'reviewed_by' => $me, 'updated_at' => $now), array('id' => $id));
+    } elseif ($action === 'reject' || $action === 'cancel') {
+        $wpdb->update($table, array('status' => 'rejected', 'reviewed_by' => $me, 'updated_at' => $now), array('id' => $id));
+    }
+
+    wp_safe_redirect($base . '&ybme_p_status=' . $action);
+    exit;
+}
+
+function ybme_pending_action_url($action, $id) {
+    return wp_nonce_url(
+        admin_url('admin.php?page=yoast-bulk-meta-editor-pending&ybme_p_action=' . $action . '&id=' . $id),
+        'ybme_pending_' . $id
+    );
+}
+
+/* -------------------------------------------------------------------------
+ * Admin page
+ * ---------------------------------------------------------------------- */
+
+// Priority 20 so the parent menu (registered at the default priority) exists.
+add_action('admin_menu', 'ybme_pending_menu', 20);
+function ybme_pending_menu() {
+    $count = ybme_pending_count();
+    $title = __('Pending Changes', YBME_TEXT_DOMAIN);
+    $menu  = $title;
+    if ($count > 0) {
+        $menu .= ' <span class="awaiting-mod"><span class="pending-count">' . number_format_i18n($count) . '</span></span>';
+    }
+    add_submenu_page(
+        'yoast-bulk-meta-editor',
+        $title,
+        $menu,
+        'manage_options',
+        'yoast-bulk-meta-editor-pending',
+        'ybme_pending_page'
+    );
+}
+
+function ybme_pending_page() {
+    if (!current_user_can('manage_options')) {
+        wp_die();
+    }
+    global $wpdb;
+    $table = ybme_pending_table();
+
+    echo '<div class="wrap">';
+    echo '<h1>' . esc_html__('Pending Changes', YBME_TEXT_DOMAIN) . '</h1>';
+
+    $status = isset($_GET['ybme_p_status']) ? sanitize_key($_GET['ybme_p_status']) : '';
+    if ($status !== '') {
+        echo '<div class="notice notice-success is-dismissible"><p>' . esc_html__('Done.', YBME_TEXT_DOMAIN) . '</p></div>';
+    }
+
+    // Active drafts: awaiting review or scheduled.
+    $active = $wpdb->get_results("SELECT * FROM {$table} WHERE status IN ('pending','scheduled') ORDER BY id DESC LIMIT 200");
+    echo '<h2>' . esc_html__('Awaiting review / scheduled', YBME_TEXT_DOMAIN) . '</h2>';
+    ybme_pending_render_table($active, true);
+
+    // Recent resolved drafts.
+    $recent = $wpdb->get_results("SELECT * FROM {$table} WHERE status IN ('applied','rejected') ORDER BY id DESC LIMIT 50");
+    echo '<h2 style="margin-top:30px;">' . esc_html__('Recently resolved', YBME_TEXT_DOMAIN) . '</h2>';
+    ybme_pending_render_table($recent, false);
+
+    echo '</div>';
+}
+
+function ybme_pending_render_table($rows, $actionable) {
+    if (empty($rows)) {
+        echo '<p>' . esc_html__('Nothing here.', YBME_TEXT_DOMAIN) . '</p>';
+        return;
+    }
+    echo '<table class="wp-list-table widefat fixed striped"><thead><tr>';
+    echo '<th>' . esc_html__('Post', YBME_TEXT_DOMAIN) . '</th>';
+    echo '<th>' . esc_html__('Field', YBME_TEXT_DOMAIN) . '</th>';
+    echo '<th>' . esc_html__('Old', YBME_TEXT_DOMAIN) . '</th>';
+    echo '<th>' . esc_html__('New', YBME_TEXT_DOMAIN) . '</th>';
+    echo '<th>' . esc_html__('Submitted by', YBME_TEXT_DOMAIN) . '</th>';
+    echo '<th>' . esc_html__('Status', YBME_TEXT_DOMAIN) . '</th>';
+    echo '<th>' . esc_html__('Scheduled for', YBME_TEXT_DOMAIN) . '</th>';
+    if ($actionable) {
+        echo '<th>' . esc_html__('Actions', YBME_TEXT_DOMAIN) . '</th>';
+    }
+    echo '</tr></thead><tbody>';
+
+    foreach ($rows as $r) {
+        $edit = get_edit_post_link($r->post_id);
+        $user = get_userdata($r->submitted_by);
+        $uname = $user ? $user->display_name : ('#' . intval($r->submitted_by));
+        echo '<tr>';
+        echo '<td>' . ($edit ? '<a href="' . esc_url($edit) . '">' . esc_html(get_the_title($r->post_id)) . '</a>' : esc_html(get_the_title($r->post_id))) . '</td>';
+        echo '<td>' . esc_html(ybme_meta_key_label($r->meta_key)) . '</td>';
+        echo '<td>' . esc_html($r->old_value) . '</td>';
+        echo '<td>' . esc_html($r->new_value) . '</td>';
+        echo '<td>' . esc_html($uname) . '</td>';
+        echo '<td>' . esc_html($r->status) . '</td>';
+        echo '<td>' . esc_html($r->scheduled_for ? $r->scheduled_for : '—') . '</td>';
+        if ($actionable) {
+            echo '<td>';
+            if ($r->status === 'pending') {
+                echo '<a class="button button-primary" href="' . esc_url(ybme_pending_action_url('approve', $r->id)) . '">' . esc_html__('Approve', YBME_TEXT_DOMAIN) . '</a> ';
+                echo '<a class="button" href="' . esc_url(ybme_pending_action_url('reject', $r->id)) . '">' . esc_html__('Reject', YBME_TEXT_DOMAIN) . '</a>';
+            } elseif ($r->status === 'scheduled') {
+                echo '<a class="button" href="' . esc_url(ybme_pending_action_url('apply', $r->id)) . '">' . esc_html__('Apply now', YBME_TEXT_DOMAIN) . '</a> ';
+                echo '<a class="button" href="' . esc_url(ybme_pending_action_url('cancel', $r->id)) . '">' . esc_html__('Cancel', YBME_TEXT_DOMAIN) . '</a>';
+            }
+            echo '</td>';
+        }
+        echo '</tr>';
+    }
+    echo '</tbody></table>';
+}
+
+/* -------------------------------------------------------------------------
+ * Scheduled apply cron
+ * ---------------------------------------------------------------------- */
+
+add_action('init', 'ybme_pending_schedule_cron');
+function ybme_pending_schedule_cron() {
+    if (!wp_next_scheduled(YBME_PENDING_CRON_HOOK)) {
+        wp_schedule_event(time() + 300, 'hourly', YBME_PENDING_CRON_HOOK);
+    }
+}
+
+add_action(YBME_PENDING_CRON_HOOK, 'ybme_pending_run_scheduled');
+function ybme_pending_run_scheduled() {
+    global $wpdb;
+    $table = ybme_pending_table();
+    $now   = current_time('mysql');
+    $rows  = $wpdb->get_results($wpdb->prepare(
+        "SELECT * FROM {$table} WHERE status = 'scheduled' AND scheduled_for IS NOT NULL AND scheduled_for <= %s",
+        $now
+    ));
+    foreach ($rows as $row) {
+        $applied = ybme_pending_apply_row($row);
+        $wpdb->update($table, array('status' => $applied ? 'applied' : 'rejected', 'updated_at' => $now), array('id' => $row->id));
+    }
+}
+
+register_deactivation_hook(YBME_PATH . 'seo-bulk-meta-editor.php', 'ybme_pending_clear_cron');
+function ybme_pending_clear_cron() {
+    wp_clear_scheduled_hook(YBME_PENDING_CRON_HOOK);
+}

--- a/index.php
+++ b/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/js/bulk-meta-editor.js
+++ b/js/bulk-meta-editor.js
@@ -8,17 +8,34 @@ jQuery(document).ready(function($) {
     var serpDevice = 'desktop';
     var $activeRow = null;
 
+    // The active SEO provider's logical-field => meta-key map, plus its reverse.
+    // Everything below works in terms of logical fields so the same code drives
+    // Yoast, Rank Math and SEOPress.
+    var fieldKeys = bulk_editor_vars.field_keys || {};
+    var keyToField = {};
+    for (var _f in fieldKeys) {
+        if (Object.prototype.hasOwnProperty.call(fieldKeys, _f)) {
+            keyToField[fieldKeys[_f]] = _f;
+        }
+    }
+
+    function fieldForKey(metaKey) {
+        return keyToField[metaKey] || '';
+    }
+
     /* --------------------------------------------------------------------
      * Helpers
      * ----------------------------------------------------------------- */
 
     function labelForKey(metaKey) {
-        return metaKey === '_yoast_wpseo_title' ? i18n.label_title :
-               metaKey === '_yoast_wpseo_metadesc' ? i18n.label_meta_description :
-               metaKey === '_yoast_wpseo_focuskw' ? i18n.label_keyword :
-               metaKey === '_yoast_wpseo_canonical' ? i18n.label_canonical_url :
-               metaKey === '_yoast_wpseo_opengraph-title' ? i18n.label_social_title :
-               metaKey;
+        switch (fieldForKey(metaKey)) {
+            case 'meta_title':       return i18n.label_title;
+            case 'meta_description': return i18n.label_meta_description;
+            case 'keyword':          return i18n.label_keyword;
+            case 'canonical_url':    return i18n.label_canonical_url;
+            case 'social_title':     return i18n.label_social_title;
+            default:                 return metaKey;
+        }
     }
 
     function logChange(postId, metaKey, oldValue, newValue) {
@@ -39,9 +56,9 @@ jQuery(document).ready(function($) {
 
     function rowFields($row) {
         return {
-            title:   rowValue($row, '_yoast_wpseo_title', 'meta-title'),
-            desc:    rowValue($row, '_yoast_wpseo_metadesc', 'meta-desc'),
-            keyword: rowValue($row, '_yoast_wpseo_focuskw', 'keyword')
+            title:   rowValue($row, fieldKeys.meta_title, 'meta-title'),
+            desc:    rowValue($row, fieldKeys.meta_description, 'meta-desc'),
+            keyword: rowValue($row, fieldKeys.keyword, 'keyword')
         };
     }
 
@@ -201,6 +218,19 @@ jQuery(document).ready(function($) {
     scoreAll();
     updateCategoryFilter();
 
+    // Honour a ?ybme_seo=... deep link from the audit dashboard by preselecting
+    // the SEO filter. (Filters the rows currently loaded in the table.)
+    (function() {
+        var match = window.location.search.match(/[?&]ybme_seo=([^&]+)/);
+        if (match) {
+            var val = decodeURIComponent(match[1]);
+            if ($('#seo-filter option[value="' + val + '"]').length) {
+                $('#seo-filter').val(val);
+                filterRows();
+            }
+        }
+    })();
+
     /* --------------------------------------------------------------------
      * Inline editing
      * ----------------------------------------------------------------- */
@@ -216,14 +246,15 @@ jQuery(document).ready(function($) {
         var $row = $cell.parent();
         var postId = $row.data('post-id');
         var metaKey = $cell.data('meta-key');
+        var field = fieldForKey(metaKey);
 
         $cell.addClass('cellEditing');
         renderSerp($row);
 
         var limit = null;
-        if (metaKey === '_yoast_wpseo_title' || metaKey === '_yoast_wpseo_opengraph-title') {
+        if (field === 'meta_title' || field === 'social_title') {
             limit = 60;
-        } else if (metaKey === '_yoast_wpseo_metadesc') {
+        } else if (field === 'meta_description') {
             limit = 160;
         }
 
@@ -253,9 +284,9 @@ jQuery(document).ready(function($) {
         $textarea.on('input', function() {
             updateCounter();
             // Live SERP preview while typing title / description.
-            if (metaKey === '_yoast_wpseo_title') {
+            if (field === 'meta_title') {
                 renderSerp($row, {title: $textarea.val()});
-            } else if (metaKey === '_yoast_wpseo_metadesc') {
+            } else if (field === 'meta_description') {
                 renderSerp($row, {desc: $textarea.val()});
             }
         });
@@ -270,14 +301,20 @@ jQuery(document).ready(function($) {
             $cell.removeClass('cellEditing');
 
             // Keep the row data attribute in sync for scoring / preview.
-            if (metaKey === '_yoast_wpseo_title') { $row.attr('data-meta-title', newContent); }
-            if (metaKey === '_yoast_wpseo_metadesc') { $row.attr('data-meta-desc', newContent); }
-            if (metaKey === '_yoast_wpseo_focuskw') { $row.attr('data-keyword', newContent); }
+            if (field === 'meta_title') { $row.attr('data-meta-title', newContent); }
+            if (field === 'meta_description') { $row.attr('data-meta-desc', newContent); }
+            if (field === 'keyword') { $row.attr('data-keyword', newContent); }
 
             if (!changes[postId]) {
                 changes[postId] = {};
             }
             changes[postId][metaKey] = newContent;
+            // Visually flag the cell as having unsaved edits.
+            if (newContent !== originalContent) {
+                $cell.addClass('ybme-dirty');
+            } else {
+                $cell.removeClass('ybme-dirty');
+            }
             logChange(postId, metaKey, originalContent, newContent);
             scoreRow($row);
             renderSerp($row);
@@ -289,30 +326,190 @@ jQuery(document).ready(function($) {
      * Save / undo
      * ----------------------------------------------------------------- */
 
-    $('#save-btn').click(function() {
+    // True when there is at least one queued (unsaved) field change.
+    function hasPendingChanges() {
         for (var postId in changes) {
-            for (var metaKey in changes[postId]) {
-                var newContent = changes[postId][metaKey];
-
-                var data = {
-                    'action': 'save_meta_info',
-                    'nonce': nonce,
-                    'post_id': postId,
-                    'meta_key': metaKey,
-                    'meta_value': newContent
-                };
-
-                $.post(ajaxurl, data, function(response) {
-                    if (response && response.success) {
-                        showNotification(i18n.meta_updated, 'success');
-                    } else {
-                        showNotification(i18n.update_failed, 'error');
+            if (Object.prototype.hasOwnProperty.call(changes, postId)) {
+                for (var metaKey in changes[postId]) {
+                    if (Object.prototype.hasOwnProperty.call(changes[postId], metaKey)) {
+                        return true;
                     }
-                }).fail(function(xhr, status, error) {
-                    showNotification(i18n.update_failed, 'error');
-                });
+                }
             }
         }
+        return false;
+    }
+
+    $('#save-btn').click(function() {
+        if (!hasPendingChanges()) {
+            showNotification(i18n.save_none, 'error');
+            return;
+        }
+
+        var $btn = $(this).prop('disabled', true);
+        // Snapshot the payload so edits made during the request aren't lost.
+        var payload = JSON.stringify(changes);
+
+        $.post(ajaxurl, {
+            'action': 'ybme_save_meta_batch',
+            'nonce': nonce,
+            'changes': payload
+        }, function(response) {
+            if (response && response.success) {
+                var d = response.data || {};
+                if (d.skipped) {
+                    showNotification(i18n.save_partial.replace('%1$d', d.saved).replace('%2$d', d.skipped), 'success');
+                } else {
+                    showNotification(i18n.save_summary.replace('%d', d.saved), 'success');
+                }
+                // Clear the queue and dirty markers so a second click can't
+                // re-submit the same edits.
+                changes = {};
+                $('#meta_info_table td.ybme-dirty').removeClass('ybme-dirty');
+            } else {
+                var msg = (response && response.data && response.data.message) ? response.data.message : i18n.update_failed;
+                showNotification(msg, 'error');
+            }
+        }).fail(function() {
+            showNotification(i18n.update_failed, 'error');
+        }).always(function() {
+            $btn.prop('disabled', false);
+        });
+    });
+
+    // Warn before navigating away with unsaved edits.
+    $(window).on('beforeunload', function() {
+        if (hasPendingChanges()) {
+            return i18n.unsaved_warning;
+        }
+    });
+
+    /* --------------------------------------------------------------------
+     * Submit for review (pending-changes module). Bound only when the
+     * module rendered its button.
+     * ----------------------------------------------------------------- */
+
+    $('#ybme-submit-review').on('click', function() {
+        $('#ybme-schedule-wrap').toggle();
+    });
+
+    $('#ybme-submit-review-go').on('click', function() {
+        if (!hasPendingChanges()) {
+            showNotification(i18n.submit_none, 'error');
+            return;
+        }
+        var $btn = $(this).prop('disabled', true);
+        $.post(ajaxurl, {
+            'action': 'ybme_pending_submit',
+            'nonce': nonce,
+            'changes': JSON.stringify(changes),
+            'scheduled_for': $('#ybme-schedule-at').val() || ''
+        }, function(response) {
+            if (response && response.success) {
+                var d = response.data || {};
+                showNotification(i18n.submit_ok.replace('%d', d.queued), 'success');
+                changes = {};
+                $('#meta_info_table td.ybme-dirty').removeClass('ybme-dirty');
+                $('#ybme-schedule-wrap').hide();
+            } else {
+                var msg = (response && response.data && response.data.message) ? response.data.message : i18n.submit_fail;
+                showNotification(msg, 'error');
+            }
+        }).fail(function() {
+            showNotification(i18n.submit_fail, 'error');
+        }).always(function() {
+            $btn.prop('disabled', false);
+        });
+    });
+
+    /* --------------------------------------------------------------------
+     * AI meta generation (ai module). Generated values land as unsaved,
+     * dirty edits for the user to review and Save / Submit.
+     * ----------------------------------------------------------------- */
+
+    // Apply a value to a field programmatically, exactly like a manual edit.
+    function commitCellValue($row, metaKey, value) {
+        var f = fieldForKey(metaKey);
+        var $cell = $row.find('td.editable[data-meta-key="' + metaKey + '"]');
+        if ($cell.length) {
+            $cell.text(value).addClass('ybme-dirty');
+        }
+        if (f === 'meta_title') { $row.attr('data-meta-title', value); }
+        if (f === 'meta_description') { $row.attr('data-meta-desc', value); }
+        if (f === 'keyword') { $row.attr('data-keyword', value); }
+        var postId = $row.data('post-id');
+        if (!changes[postId]) { changes[postId] = {}; }
+        changes[postId][metaKey] = value;
+        logChange(postId, metaKey, '', value);
+    }
+
+    function aiGenerateRow($row, done) {
+        var postId = $row.data('post-id');
+        $.post(ajaxurl, {
+            'action': 'ybme_ai_generate',
+            'nonce': nonce,
+            'post_id': postId
+        }, function(resp) {
+            if (resp && resp.success) {
+                var d = resp.data || {};
+                if (d.title) { commitCellValue($row, fieldKeys.meta_title, d.title); }
+                if (d.description) { commitCellValue($row, fieldKeys.meta_description, d.description); }
+                scoreRow($row);
+                renderSerp($row);
+                filterRows();
+                done(true);
+            } else {
+                done(false, (resp && resp.data && resp.data.message) ? resp.data.message : i18n.ai_failed);
+            }
+        }).fail(function() {
+            done(false, i18n.ai_failed);
+        });
+    }
+
+    $(document).on('click', '.ybme-ai-generate', function() {
+        var $btn = $(this);
+        var $row = $btn.closest('tr');
+        $btn.prop('disabled', true).text(i18n.ai_generating);
+        aiGenerateRow($row, function(ok, msg) {
+            $btn.prop('disabled', false).text(i18n.ai_generate);
+            if (!ok) {
+                showNotification(msg || i18n.ai_failed, 'error');
+            }
+        });
+    });
+
+    $('#ybme-ai-bulk').on('click', function() {
+        var $rows = $('#meta_info_table tbody tr:visible').filter(function() {
+            var lvl = $(this).attr('data-seo-level');
+            return lvl === 'warn' || lvl === 'bad';
+        });
+        var cap = 25;
+        if ($rows.length > cap) {
+            $rows = $rows.slice(0, cap);
+        }
+        if (!$rows.length) {
+            showNotification(i18n.ai_no_rows, 'error');
+            return;
+        }
+        if (!window.confirm(i18n.ai_bulk_confirm.replace('%d', $rows.length))) {
+            return;
+        }
+        var $btn = $(this).prop('disabled', true);
+        var idx = 0, okCount = 0;
+        function next() {
+            if (idx >= $rows.length) {
+                $btn.prop('disabled', false);
+                showNotification(i18n.ai_bulk_done.replace('%d', okCount), 'success');
+                return;
+            }
+            var $row = $rows.eq(idx++);
+            showNotification(i18n.ai_generating + ' (' + idx + '/' + $rows.length + ')', 'success');
+            aiGenerateRow($row, function(ok) {
+                if (ok) { okCount++; }
+                next();
+            });
+        }
+        next();
     });
 
     $('#undo-btn').click(function() {
@@ -332,9 +529,10 @@ jQuery(document).ready(function($) {
         }
         changes[last.postId][last.metaKey] = last.oldValue;
 
-        if (last.metaKey === '_yoast_wpseo_title') { $row.attr('data-meta-title', last.oldValue); }
-        if (last.metaKey === '_yoast_wpseo_metadesc') { $row.attr('data-meta-desc', last.oldValue); }
-        if (last.metaKey === '_yoast_wpseo_focuskw') { $row.attr('data-keyword', last.oldValue); }
+        var undoField = fieldForKey(last.metaKey);
+        if (undoField === 'meta_title') { $row.attr('data-meta-title', last.oldValue); }
+        if (undoField === 'meta_description') { $row.attr('data-meta-desc', last.oldValue); }
+        if (undoField === 'keyword') { $row.attr('data-keyword', last.oldValue); }
 
         var data = {
             'action': 'save_meta_info',

--- a/js/index.php
+++ b/js/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/languages/index.php
+++ b/languages/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<ruleset name="SEO Bulk Meta Editor">
+    <description>Coding standards for the Yoast SEO Bulk Meta Editor plugin.</description>
+
+    <!-- Scan the plugin's PHP, ignoring dependencies and vendored assets. -->
+    <file>.</file>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/node_modules/*</exclude-pattern>
+    <exclude-pattern>*/js/*.min.js</exclude-pattern>
+
+    <arg name="extensions" value="php"/>
+    <arg name="colors"/>
+    <arg value="sp"/>
+
+    <!-- WordPress standards. -->
+    <rule ref="WordPress-Core"/>
+    <rule ref="WordPress-Docs"/>
+
+    <!-- Text-domain and prefix checks. -->
+    <rule ref="WordPress.WP.I18n">
+        <properties>
+            <property name="text_domain" type="array">
+                <element value="seo-bulk-meta-editor"/>
+            </property>
+        </properties>
+    </rule>
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+        <properties>
+            <property name="prefixes" type="array">
+                <element value="ybme"/>
+                <element value="YBME"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Target the minimum supported PHP version. -->
+    <config name="testVersion" value="7.2-"/>
+    <rule ref="PHPCompatibilityWP"/>
+
+    <!-- Minimum supported WordPress version. -->
+    <config name="minimum_wp_version" value="5.0"/>
+</ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
 === Yoast SEO Bulk Meta Editor ===
 Contributors: costibotez
 Donate link: https://www.buymeacoffee.com/costinbotez
-Tags: seo, yoast, meta description, bulk edit, serp preview
+Tags: seo, yoast, rank math, seopress, bulk edit
 Requires at least: 5.0
 Tested up to: 6.5
 Requires PHP: 7.2
-Stable tag: 1.6.0
+Stable tag: 1.12.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -34,11 +34,15 @@ On top of fast inline editing, the plugin helps you write snippets that actually
 * Per-row SEO health score: a traffic-light dot flags missing titles/descriptions/keywords and length problems, with details on hover.
 * "Show only problems" filter to instantly narrow the table to rows that need attention.
 * Bulk find & replace across meta titles, descriptions or keywords for every matching post, with a preview of affected rows before you apply. Supports case sensitivity, regular expressions and template variables (%%title%%, %%sitename%%, %%sep%%).
+* Site-wide SEO audit dashboard: score distribution, missing/over/under-length fields by post type, and duplicate meta title/description detection across posts, with one-click jumps into the editor.
+* Google Search Console integration: connect a property over OAuth and show clicks, impressions, CTR and average position per URL as optional editor columns.
+* AI meta generation: draft meta titles and descriptions from page content with your own Claude or OpenAI key, per row or in bulk, always as a preview you approve before saving.
 
 **Safety & history**
 
 * Change history / audit log: every edit (single, undo, revert or bulk) is recorded to the database with the old value, new value, user and timestamp.
 * One-click revert from the History page.
+* Draft & scheduled changes with an approval workflow: submit edits for review, and let an administrator approve, reject or schedule them for automatic application.
 
 **Security**
 
@@ -46,7 +50,7 @@ On top of fast inline editing, the plugin helps you write snippets that actually
 * Meta writes are restricted to an allow-list of Yoast keys, with per-post edit permission checks.
 * All values are escaped on output and sanitized per field on save.
 
-Requires the [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/) plugin to be installed and active.
+Requires one supported SEO plugin to be installed and active: [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/), [Rank Math](https://wordpress.org/plugins/seo-by-rank-math/) or [SEOPress](https://wordpress.org/plugins/wp-seopress/). All in One SEO stores its data in a custom table rather than post meta and is not supported.
 
 == Installation ==
 
@@ -66,9 +70,9 @@ Requires the [Yoast SEO](https://wordpress.org/plugins/wordpress-seo/) plugin to
 
 == Frequently Asked Questions ==
 
-= Does this require Yoast SEO? =
+= Which SEO plugins are supported? =
 
-Yes. The plugin reads and writes Yoast SEO meta keys, so Yoast SEO must be installed and active.
+Yoast SEO, Rank Math and SEOPress. One of them must be installed and active. The plugin auto-detects which is in use, or you can choose explicitly on the Settings page. All in One SEO is not supported because it stores its data in a custom database table rather than in post meta.
 
 = Who can edit metadata? =
 
@@ -77,6 +81,10 @@ Access is controlled by a dedicated capability. By default only administrators h
 = Can I undo a bulk find & replace? =
 
 Every change made through the plugin — including bulk replacements — is logged. You can revert individual changes from the History page.
+
+= How does the AI generation work, and is my content sent anywhere? =
+
+It is optional and off until you add your own Claude (Anthropic) or OpenAI API key on the AI Assistant page. When you click Generate, the post's title and a content excerpt are sent to the provider you selected, and the suggested title and description are shown as unsaved edits for you to review. Nothing is written or sent automatically.
 
 = Does it work with WPML? =
 
@@ -89,6 +97,46 @@ Yes. When WPML is active, a language column with flags is shown and you can filt
 3. The change history / audit log with one-click revert.
 
 == Changelog ==
+
+= 1.12.0 =
+* New: AI-assisted meta generation. With your own Claude (Anthropic) or OpenAI API key, a per-row "Generate" button drafts a meta title and description from the post's content, and an "AI: fill problem rows" button does the same in bulk for visible rows that need attention.
+* New: Generated values are inserted as unsaved, highlighted edits so you always review them before saving or submitting for review — nothing is written automatically.
+* New: An "AI Assistant" settings page to choose the provider, enter the API key and optionally set the model.
+
+= 1.11.0 =
+* New: Draft & scheduled changes with an approval workflow. A "Submit for Review" button queues edits as drafts (with an optional future apply time) instead of saving directly.
+* New: A "Pending Changes" admin page where administrators approve, reject, apply-now or cancel drafts. Approved drafts with a future time are applied automatically by WP-Cron, validated and logged to the change history like a direct save.
+* Dev: Added ybme_install_tables, ybme_editor_actions and ybme_editor_js_vars extension hooks.
+
+= 1.10.0 =
+* New: Google Search Console integration. Connect a property over OAuth and add optional Clicks / Impressions / CTR / Position columns (last ~28 days) to the editor, to prioritise rewriting metas on high-impression, low-CTR pages.
+* New: A Search Console admin page to enter credentials, connect/disconnect, choose the property and refresh data. Metrics also refresh daily via WP-Cron and are cached.
+* Dev: Introduced an includes/ module layer and two extension filters (ybme_available_columns, ybme_render_column_cell) for adding read-only columns.
+
+= 1.9.0 =
+* New: Multi-plugin support. The editor, audit and find & replace now work with Rank Math and SEOPress in addition to Yoast SEO, via a provider abstraction over each plugin's meta keys.
+* New: The active SEO plugin is auto-detected (Yoast, then Rank Math, then SEOPress), or you can pick one explicitly on the Settings page.
+* Change: The plugin now requires any one of the supported SEO plugins to be active (previously Yoast specifically). Admin notices, the activation check and all write guards were updated accordingly.
+* Note: All in One SEO stores its data in a custom table rather than post meta, so it is not supported by this release.
+
+= 1.8.0 =
+* New: Site-wide SEO Audit dashboard (new Audit submenu) with a good/needs-work/critical score distribution, a per-issue breakdown (missing and over/under-length titles and descriptions, missing keywords), a per-post-type breakdown, and cross-post duplicate meta title/description detection with direct edit links.
+* New: Audit cards deep-link into the editor with the SEO filter pre-applied. Results are cached for 10 minutes and refresh automatically whenever a meta value changes, or on demand via the Refresh button.
+
+= 1.7.0 =
+* Improvement: "Save Changes" now saves every edit in a single AJAX request with one summary notification, instead of one request (and one toast) per field.
+* Improvement: The edit queue is cleared after a successful save, so pressing Save twice no longer re-submits the same edits.
+* New: Unsaved-changes guard — the browser warns before navigating away with pending edits, and edited cells are highlighted until saved.
+* Fix: Settings registration is now hooked on admin_init at the top level rather than from inside the admin_menu callback.
+* Dev: Added Composer config, PHP_CodeSniffer (WordPress Coding Standards) ruleset and a GitHub Actions lint workflow.
+
+= 1.6.1 =
+* Security: All settings (post types, columns, roles, rows-per-page, languages, license key) are now sanitized and validated on save against known-good values.
+* Security: Rows-per-page is clamped (1–200) so the editor can no longer be made to query thousands of posts in one request.
+* Security: Bulk find & replace rejects over-long find/replace input to limit exposure to catastrophic-backtracking (ReDoS) patterns.
+* Security: Added directory-listing guards (index.php) to the plugin folders.
+* New: Uninstall cleanup removes the plugin's options, custom capability and history table when the plugin is deleted.
+* New: Runtime Yoast SEO check — shows an admin notice and blocks writes when Yoast is inactive, instead of silently writing orphaned meta.
 
 = 1.6.0 =
 * New: Live Google (SERP) preview with desktop/mobile layouts that updates while you type.
@@ -111,6 +159,27 @@ Yes. When WPML is active, a language column with flags is shown and you can filt
 * Added configurable rows per page, selectable columns and allowed roles.
 
 == Upgrade Notice ==
+
+= 1.12.0 =
+Adds AI meta generation with your own Claude or OpenAI key: draft titles and descriptions per row or in bulk, always previewed before saving.
+
+= 1.11.0 =
+Adds a draft & scheduled changes approval workflow: submit edits for review and let an admin approve, reject or schedule them.
+
+= 1.10.0 =
+Adds Google Search Console integration: connect a property and show clicks, impressions, CTR and position per URL as optional editor columns.
+
+= 1.9.0 =
+Now works with Rank Math and SEOPress in addition to Yoast SEO. The active SEO plugin is auto-detected, or selectable on the Settings page.
+
+= 1.8.0 =
+Adds a site-wide SEO Audit dashboard: score distribution, issue and post-type breakdowns, and duplicate meta detection, with deep links into the editor.
+
+= 1.7.0 =
+Faster, safer saving: all edits save in one request, the queue clears on success, and you're warned before leaving with unsaved changes.
+
+= 1.6.1 =
+Security and robustness release: settings validation, rows-per-page clamping, find & replace input limits, uninstall cleanup and a runtime Yoast check. Recommended for all users.
 
 = 1.6.0 =
 Adds a live Google preview, SEO scoring, bulk find & replace and a change-history/audit log, plus important security hardening. Recommended for all users.

--- a/seo-bulk-meta-editor.php
+++ b/seo-bulk-meta-editor.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Plugin Name: Yoast SEO Bulk Meta Editor
- * Description: Display & edit all meta titles, descriptions, and keywords from all posts, pages, and custom post types into one dashboard. Includes a live SERP preview, per-row SEO health scoring, bulk find & replace and a full change-history/audit log.
- * Version: 1.6.0
+ * Description: Display & edit all meta titles, descriptions, and keywords from all posts, pages, and custom post types into one dashboard. Works with Yoast SEO, Rank Math and SEOPress. Includes a live SERP preview, per-row SEO health scoring, a site-wide audit, Google Search Console metrics, AI meta generation, an approval workflow, bulk find & replace and a full change-history/audit log.
+ * Version: 1.12.0
  * Plugin URI: https://nomad-developer.co.uk
  * Author: Nomad Developer
  * Author URI:  https://nomad-developer.co.uk
@@ -20,12 +20,19 @@ define('YBME_POSTS_PER_PAGE', 20);
 define('YBME_TEXT_DOMAIN', 'seo-bulk-meta-editor');
 
 // Plugin + database schema version.
-define('YBME_VERSION', '1.6.0');
+define('YBME_VERSION', '1.12.0');
 
 define('YBME_CAPABILITY', 'manage_ybme_meta');
 
 // Shared nonce action used to protect every AJAX write.
 define('YBME_NONCE_ACTION', 'ybme_meta_action');
+
+define('YBME_PATH', plugin_dir_path(__FILE__));
+
+// Optional feature modules.
+require_once YBME_PATH . 'includes/gsc.php';
+require_once YBME_PATH . 'includes/pending.php';
+require_once YBME_PATH . 'includes/ai.php';
 
 function ybme_load_textdomain() {
     load_plugin_textdomain(YBME_TEXT_DOMAIN, false, dirname(plugin_basename(__FILE__)) . '/languages');
@@ -45,21 +52,151 @@ function ybme_get_wpml_languages() {
     return is_array($langs) ? $langs : array();
 }
 
+/* -------------------------------------------------------------------------
+ * SEO plugin providers
+ *
+ * The editor, audit and find & replace all read and write post meta. Each
+ * supported SEO plugin stores the same logical fields under different meta
+ * keys, so the whole plugin operates on a per-provider key map instead of
+ * hard-coded Yoast keys.
+ *
+ * Only post-meta based plugins fit this model. All in One SEO (AIOSEO v4)
+ * stores its data in a custom table, not post meta, so it is intentionally
+ * not offered here.
+ * ---------------------------------------------------------------------- */
+
+/**
+ * Registry of supported SEO plugins. Each entry maps the plugin's own meta
+ * keys onto the five logical fields the editor understands.
+ */
+function ybme_providers() {
+    return array(
+        'yoast' => array(
+            'label'  => 'Yoast SEO',
+            'fields' => array(
+                'meta_title'       => '_yoast_wpseo_title',
+                'meta_description' => '_yoast_wpseo_metadesc',
+                'keyword'          => '_yoast_wpseo_focuskw',
+                'canonical_url'    => '_yoast_wpseo_canonical',
+                'social_title'     => '_yoast_wpseo_opengraph-title',
+            ),
+        ),
+        'rankmath' => array(
+            'label'  => 'Rank Math',
+            'fields' => array(
+                'meta_title'       => 'rank_math_title',
+                'meta_description' => 'rank_math_description',
+                'keyword'          => 'rank_math_focus_keyword',
+                'canonical_url'    => 'rank_math_canonical_url',
+                'social_title'     => 'rank_math_facebook_title',
+            ),
+        ),
+        'seopress' => array(
+            'label'  => 'SEOPress',
+            'fields' => array(
+                'meta_title'       => '_seopress_titles_title',
+                'meta_description' => '_seopress_titles_desc',
+                'keyword'          => '_seopress_analysis_target_kw',
+                'canonical_url'    => '_seopress_robots_canonical',
+                'social_title'     => '_seopress_social_fb_title',
+            ),
+        ),
+    );
+}
+
+// Priority order used when more than one supported plugin is active.
+function ybme_provider_priority() {
+    return array('yoast', 'rankmath', 'seopress');
+}
+
+/**
+ * Is a given provider's plugin loaded right now?
+ */
+function ybme_provider_is_available($id) {
+    switch ($id) {
+        case 'yoast':
+            return defined('WPSEO_VERSION') || class_exists('WPSEO_Options');
+        case 'rankmath':
+            return defined('RANK_MATH_VERSION') || class_exists('RankMath');
+        case 'seopress':
+            return defined('SEOPRESS_VERSION') || function_exists('seopress_init');
+    }
+    return false;
+}
+
+/**
+ * The id of the active provider: an explicit, still-available choice from
+ * settings, otherwise the first available plugin in priority order. Empty
+ * string when no supported SEO plugin is active.
+ */
+function ybme_active_provider_id() {
+    $providers = ybme_providers();
+
+    $saved = get_option('ybme_provider', '');
+    if ($saved && isset($providers[$saved]) && ybme_provider_is_available($saved)) {
+        return $saved;
+    }
+    foreach (ybme_provider_priority() as $id) {
+        if (ybme_provider_is_available($id)) {
+            return $id;
+        }
+    }
+    return '';
+}
+
+function ybme_provider_active() {
+    return ybme_active_provider_id() !== '';
+}
+
+/**
+ * The logical-field => meta-key map for the active provider. Falls back to
+ * Yoast's keys so nothing fatals when no provider is active.
+ */
+function ybme_provider_field_keys() {
+    $id        = ybme_active_provider_id();
+    $providers = ybme_providers();
+    if ($id && isset($providers[$id])) {
+        return $providers[$id]['fields'];
+    }
+    return $providers['yoast']['fields'];
+}
+
+/**
+ * Reverse lookup: which logical field does a meta key belong to? Checks every
+ * provider so history rows written under a previously-active plugin still
+ * resolve. Empty string when unknown.
+ */
+function ybme_field_for_key($meta_key) {
+    foreach (ybme_providers() as $provider) {
+        $field = array_search($meta_key, $provider['fields'], true);
+        if ($field !== false) {
+            return $field;
+        }
+    }
+    return '';
+}
+
 function ybme_get_available_columns() {
+    $keys = ybme_provider_field_keys();
     $cols = array(
         'seo_score'        => array('label' => __('SEO', YBME_TEXT_DOMAIN)),
         'title'            => array('label' => __('Title', YBME_TEXT_DOMAIN)),
         'post_type'        => array('label' => __('Post Type', YBME_TEXT_DOMAIN)),
-        'meta_title'       => array('label' => __('Meta Title', YBME_TEXT_DOMAIN), 'meta_key' => '_yoast_wpseo_title'),
-        'meta_description' => array('label' => __('Meta Description', YBME_TEXT_DOMAIN), 'meta_key' => '_yoast_wpseo_metadesc'),
-        'keyword'          => array('label' => __('Keyword', YBME_TEXT_DOMAIN), 'meta_key' => '_yoast_wpseo_focuskw'),
-        'canonical_url'    => array('label' => __('Canonical URL', YBME_TEXT_DOMAIN), 'meta_key' => '_yoast_wpseo_canonical'),
-        'social_title'     => array('label' => __('Social Title', YBME_TEXT_DOMAIN), 'meta_key' => '_yoast_wpseo_opengraph-title'),
+        'meta_title'       => array('label' => __('Meta Title', YBME_TEXT_DOMAIN), 'meta_key' => $keys['meta_title']),
+        'meta_description' => array('label' => __('Meta Description', YBME_TEXT_DOMAIN), 'meta_key' => $keys['meta_description']),
+        'keyword'          => array('label' => __('Keyword', YBME_TEXT_DOMAIN), 'meta_key' => $keys['keyword']),
+        'canonical_url'    => array('label' => __('Canonical URL', YBME_TEXT_DOMAIN), 'meta_key' => $keys['canonical_url']),
+        'social_title'     => array('label' => __('Social Title', YBME_TEXT_DOMAIN), 'meta_key' => $keys['social_title']),
     );
     if (ybme_wpml_active()) {
         $cols = array_merge(array('language_flag' => array('label' => __('Language', YBME_TEXT_DOMAIN))), $cols);
     }
-    return $cols;
+    /**
+     * Filter the available editor columns. Feature modules (e.g. Search
+     * Console) add read-only columns here. Columns without a 'meta_key' are
+     * never writable and are ignored by the save allow-list.
+     */
+    return apply_filters('ybme_available_columns', $cols);
 }
 
 function ybme_get_enabled_columns() {
@@ -75,9 +212,10 @@ function ybme_get_enabled_columns() {
 }
 
 /**
- * The complete set of Yoast meta keys this plugin is allowed to write.
- * Any AJAX handler that saves meta MUST validate against this list so a
- * crafted request can never target arbitrary post meta (e.g. _wp_page_template).
+ * The complete set of meta keys this plugin is allowed to write for the active
+ * SEO provider. Any AJAX handler that saves meta MUST validate against this
+ * list so a crafted request can never target arbitrary post meta (e.g.
+ * _wp_page_template).
  */
 function ybme_allowed_meta_keys() {
     $keys = array();
@@ -90,13 +228,15 @@ function ybme_allowed_meta_keys() {
 }
 
 /**
- * Sanitize a meta value according to the field it belongs to.
+ * Sanitize a meta value according to the logical field it belongs to, so the
+ * right rule applies regardless of which provider's key it is.
  */
 function ybme_sanitize_meta_value($meta_key, $value) {
-    if ($meta_key === '_yoast_wpseo_canonical') {
+    $field = ybme_field_for_key($meta_key);
+    if ($field === 'canonical_url') {
         return esc_url_raw($value);
     }
-    if ($meta_key === '_yoast_wpseo_metadesc') {
+    if ($field === 'meta_description') {
         return sanitize_textarea_field($value);
     }
     return sanitize_text_field($value);
@@ -114,9 +254,316 @@ function ybme_meta_key_label($meta_key) {
     return $meta_key;
 }
 
+// Rows to show per batch, clamped even if an oversized value was stored before
+// the save-time sanitizer existed.
+function ybme_get_rows_per_page() {
+    return ybme_sanitize_rows_per_page(get_option('ybme_rows_per_page', YBME_POSTS_PER_PAGE));
+}
+
 function ybme_is_pro() {
     $key = trim(get_option('ybme_license_key'));
     return !empty($key);
+}
+
+/* -------------------------------------------------------------------------
+ * Site-wide SEO audit
+ *
+ * Scans every published post of the selected post types and aggregates the
+ * same signals the per-row score dot uses (missing / too long / too short
+ * title & description, missing keyword) plus cross-post duplicate detection.
+ * The result is cached in a transient so the page is cheap to reopen.
+ * ---------------------------------------------------------------------- */
+
+define('YBME_AUDIT_TRANSIENT', 'ybme_audit_cache');
+
+// Post types the audit scans (same selection the editor uses).
+function ybme_audit_post_types() {
+    $types = get_option('post_types', array('post', 'page'));
+    if (!is_array($types) || empty($types)) {
+        $types = array('post', 'page');
+    }
+    return $types;
+}
+
+/**
+ * Walk all published posts and build the audit statistics array.
+ *
+ * Length thresholds and the good/warn/bad classification intentionally mirror
+ * scoreFields() in js/bulk-meta-editor.js so the dashboard and the editor's
+ * score dots always agree.
+ */
+function ybme_run_audit() {
+    $ids = get_posts(array(
+        'post_type'        => ybme_audit_post_types(),
+        'post_status'      => 'publish',
+        'numberposts'      => -1,
+        'fields'           => 'ids',
+        'orderby'          => 'ID',
+        'order'            => 'ASC',
+        'suppress_filters' => true,
+    ));
+
+    $stats = array(
+        'generated'       => current_time('mysql'),
+        'total'           => count($ids),
+        'missing_title'   => 0,
+        'missing_desc'    => 0,
+        'missing_keyword' => 0,
+        'title_long'      => 0,
+        'title_short'     => 0,
+        'desc_long'       => 0,
+        'desc_short'      => 0,
+        'good'            => 0,
+        'warn'            => 0,
+        'bad'             => 0,
+        'by_type'         => array(),
+        'dupe_titles'     => array(),
+        'dupe_descs'      => array(),
+    );
+
+    // Maps a normalized value to the post IDs that share it, plus the first
+    // original spelling seen (for display).
+    $title_ids = array();
+    $desc_ids  = array();
+    $title_txt = array();
+    $desc_txt  = array();
+
+    // Read the active provider's keys once rather than per post.
+    $fk        = ybme_provider_field_keys();
+    $key_title = $fk['meta_title'];
+    $key_desc  = $fk['meta_description'];
+    $key_kw    = $fk['keyword'];
+
+    foreach (array_chunk($ids, 500) as $chunk) {
+        // Prime post + meta caches for the whole chunk in two queries rather
+        // than one per get_post_type()/get_post_meta() call.
+        _prime_post_caches($chunk, false, true);
+
+        foreach ($chunk as $pid) {
+            $type = get_post_type($pid);
+            if (!isset($stats['by_type'][$type])) {
+                $stats['by_type'][$type] = array(
+                    'total'           => 0,
+                    'missing_title'   => 0,
+                    'missing_desc'    => 0,
+                    'missing_keyword' => 0,
+                );
+            }
+            $stats['by_type'][$type]['total']++;
+
+            $title = trim((string) get_post_meta($pid, $key_title, true));
+            $desc  = trim((string) get_post_meta($pid, $key_desc, true));
+            $kw    = trim((string) get_post_meta($pid, $key_kw, true));
+
+            $critical  = false;
+            $has_issue = false;
+
+            if ($title === '') {
+                $stats['missing_title']++;
+                $stats['by_type'][$type]['missing_title']++;
+                $critical = true;
+            } else {
+                $len = function_exists('mb_strlen') ? mb_strlen($title) : strlen($title);
+                if ($len > 60) { $stats['title_long']++; $has_issue = true; }
+                elseif ($len < 30) { $stats['title_short']++; $has_issue = true; }
+                $key = function_exists('mb_strtolower') ? mb_strtolower($title) : strtolower($title);
+                if (!isset($title_ids[$key])) { $title_ids[$key] = array(); $title_txt[$key] = $title; }
+                $title_ids[$key][] = $pid;
+            }
+
+            if ($desc === '') {
+                $stats['missing_desc']++;
+                $stats['by_type'][$type]['missing_desc']++;
+                $critical = true;
+            } else {
+                $len = function_exists('mb_strlen') ? mb_strlen($desc) : strlen($desc);
+                if ($len > 160) { $stats['desc_long']++; $has_issue = true; }
+                elseif ($len < 120) { $stats['desc_short']++; $has_issue = true; }
+                $key = function_exists('mb_strtolower') ? mb_strtolower($desc) : strtolower($desc);
+                if (!isset($desc_ids[$key])) { $desc_ids[$key] = array(); $desc_txt[$key] = $desc; }
+                $desc_ids[$key][] = $pid;
+            }
+
+            if ($kw === '') {
+                $stats['missing_keyword']++;
+                $stats['by_type'][$type]['missing_keyword']++;
+                $has_issue = true;
+            }
+
+            if ($critical) {
+                $stats['bad']++;
+            } elseif ($has_issue) {
+                $stats['warn']++;
+            } else {
+                $stats['good']++;
+            }
+        }
+    }
+
+    // Reduce the value maps to duplicate groups (2+ posts sharing a value).
+    $stats['dupe_titles'] = ybme_audit_dupes($title_ids, $title_txt);
+    $stats['dupe_descs']  = ybme_audit_dupes($desc_ids, $desc_txt);
+
+    return $stats;
+}
+
+/**
+ * Turn a value => [post_ids] map into a capped, sorted list of duplicate groups.
+ */
+function ybme_audit_dupes($id_map, $txt_map) {
+    $groups = array();
+    foreach ($id_map as $key => $ids) {
+        if (count($ids) > 1) {
+            $groups[] = array(
+                'value' => $txt_map[$key],
+                'count' => count($ids),
+                'ids'   => array_slice($ids, 0, 25),
+            );
+        }
+    }
+    usort($groups, function ($a, $b) {
+        return $b['count'] - $a['count'];
+    });
+    return array_slice($groups, 0, 50);
+}
+
+/**
+ * Return the cached audit, computing (and caching) it when missing or forced.
+ */
+function ybme_get_audit_data($force = false) {
+    if (!$force) {
+        $cached = get_transient(YBME_AUDIT_TRANSIENT);
+        if (is_array($cached)) {
+            return $cached;
+        }
+    }
+    $data = ybme_run_audit();
+    set_transient(YBME_AUDIT_TRANSIENT, $data, 10 * MINUTE_IN_SECONDS);
+    return $data;
+}
+
+// Drop the cache whenever a meta value changes so the audit never goes stale.
+function ybme_clear_audit_cache() {
+    delete_transient(YBME_AUDIT_TRANSIENT);
+}
+
+/**
+ * Render the audit dashboard.
+ */
+function ybme_audit_page() {
+    if (!current_user_can(YBME_CAPABILITY)) { wp_die(); }
+
+    $force = false;
+    if (isset($_GET['ybme_refresh'])) {
+        check_admin_referer('ybme_audit_refresh');
+        $force = true;
+    }
+
+    $d          = ybme_get_audit_data($force);
+    $editor_url = admin_url('admin.php?page=yoast-bulk-meta-editor');
+    $refresh    = wp_nonce_url(admin_url('admin.php?page=yoast-bulk-meta-editor-audit&ybme_refresh=1'), 'ybme_audit_refresh');
+
+    echo '<div class="wrap">';
+    echo '<h1>' . esc_html__('SEO Audit', YBME_TEXT_DOMAIN) . '</h1>';
+
+    if (!ybme_provider_active()) {
+        echo '<div class="notice notice-error inline"><p>' . esc_html__('No supported SEO plugin is active. Audit results may be incomplete.', YBME_TEXT_DOMAIN) . '</p></div>';
+    }
+
+    echo '<p class="description">' . sprintf(
+        /* translators: 1: number of posts, 2: date/time the audit was generated */
+        esc_html__('Scanned %1$d published items. Generated %2$s.', YBME_TEXT_DOMAIN),
+        intval($d['total']),
+        esc_html($d['generated'])
+    ) . ' <a href="' . esc_url($refresh) . '" class="button button-small">' . esc_html__('Refresh', YBME_TEXT_DOMAIN) . '</a></p>';
+
+    // Score distribution cards.
+    $problems = intval($d['warn']) + intval($d['bad']);
+    echo '<div class="ybme-audit-cards">';
+    echo '<div class="ybme-audit-card"><span class="ybme-audit-num">' . intval($d['total']) . '</span><span class="ybme-audit-cap">' . esc_html__('Total', YBME_TEXT_DOMAIN) . '</span></div>';
+    echo '<a class="ybme-audit-card is-good" href="' . esc_url($editor_url . '&ybme_seo=good') . '"><span class="ybme-audit-num">' . intval($d['good']) . '</span><span class="ybme-audit-cap">' . esc_html__('Good', YBME_TEXT_DOMAIN) . '</span></a>';
+    echo '<a class="ybme-audit-card is-warn" href="' . esc_url($editor_url . '&ybme_seo=problems') . '"><span class="ybme-audit-num">' . intval($d['warn']) . '</span><span class="ybme-audit-cap">' . esc_html__('Needs work', YBME_TEXT_DOMAIN) . '</span></a>';
+    echo '<a class="ybme-audit-card is-bad" href="' . esc_url($editor_url . '&ybme_seo=bad') . '"><span class="ybme-audit-num">' . intval($d['bad']) . '</span><span class="ybme-audit-cap">' . esc_html__('Critical', YBME_TEXT_DOMAIN) . '</span></a>';
+    echo '</div>';
+
+    // Issue breakdown.
+    echo '<h2>' . esc_html__('Issues', YBME_TEXT_DOMAIN) . '</h2>';
+    echo '<table class="wp-list-table widefat fixed striped"><tbody>';
+    $issue_rows = array(
+        __('Missing meta title', YBME_TEXT_DOMAIN)           => $d['missing_title'],
+        __('Missing meta description', YBME_TEXT_DOMAIN)     => $d['missing_desc'],
+        __('Missing focus keyword', YBME_TEXT_DOMAIN)        => $d['missing_keyword'],
+        __('Title too long (over 60)', YBME_TEXT_DOMAIN)     => $d['title_long'],
+        __('Title too short (under 30)', YBME_TEXT_DOMAIN)   => $d['title_short'],
+        __('Description too long (over 160)', YBME_TEXT_DOMAIN)   => $d['desc_long'],
+        __('Description too short (under 120)', YBME_TEXT_DOMAIN) => $d['desc_short'],
+    );
+    foreach ($issue_rows as $label => $count) {
+        echo '<tr><td>' . esc_html($label) . '</td><td style="width:80px;text-align:right;"><strong>' . intval($count) . '</strong></td></tr>';
+    }
+    echo '</tbody></table>';
+
+    // Breakdown by post type.
+    if (!empty($d['by_type'])) {
+        echo '<h2>' . esc_html__('By post type', YBME_TEXT_DOMAIN) . '</h2>';
+        echo '<table class="wp-list-table widefat fixed striped"><thead><tr>';
+        echo '<th>' . esc_html__('Post type', YBME_TEXT_DOMAIN) . '</th>';
+        echo '<th>' . esc_html__('Total', YBME_TEXT_DOMAIN) . '</th>';
+        echo '<th>' . esc_html__('No title', YBME_TEXT_DOMAIN) . '</th>';
+        echo '<th>' . esc_html__('No description', YBME_TEXT_DOMAIN) . '</th>';
+        echo '<th>' . esc_html__('No keyword', YBME_TEXT_DOMAIN) . '</th>';
+        echo '</tr></thead><tbody>';
+        foreach ($d['by_type'] as $type => $t) {
+            $obj  = get_post_type_object($type);
+            $name = ($obj && isset($obj->labels->name)) ? $obj->labels->name : $type;
+            echo '<tr>';
+            echo '<td>' . esc_html($name) . '</td>';
+            echo '<td>' . intval($t['total']) . '</td>';
+            echo '<td>' . intval($t['missing_title']) . '</td>';
+            echo '<td>' . intval($t['missing_desc']) . '</td>';
+            echo '<td>' . intval($t['missing_keyword']) . '</td>';
+            echo '</tr>';
+        }
+        echo '</tbody></table>';
+    }
+
+    ybme_audit_dupe_table(__('Duplicate meta titles', YBME_TEXT_DOMAIN), $d['dupe_titles']);
+    ybme_audit_dupe_table(__('Duplicate meta descriptions', YBME_TEXT_DOMAIN), $d['dupe_descs']);
+
+    echo '</div>';
+}
+
+/**
+ * Render one duplicate-group table (titles or descriptions).
+ */
+function ybme_audit_dupe_table($heading, $groups) {
+    echo '<h2>' . esc_html($heading) . '</h2>';
+    if (empty($groups)) {
+        echo '<p>' . esc_html__('No duplicates found.', YBME_TEXT_DOMAIN) . '</p>';
+        return;
+    }
+    echo '<table class="wp-list-table widefat fixed striped"><thead><tr>';
+    echo '<th>' . esc_html__('Value', YBME_TEXT_DOMAIN) . '</th>';
+    echo '<th style="width:60px;">' . esc_html__('Count', YBME_TEXT_DOMAIN) . '</th>';
+    echo '<th>' . esc_html__('Posts', YBME_TEXT_DOMAIN) . '</th>';
+    echo '</tr></thead><tbody>';
+    foreach ($groups as $g) {
+        echo '<tr>';
+        echo '<td>' . esc_html($g['value']) . '</td>';
+        echo '<td><strong>' . intval($g['count']) . '</strong></td>';
+        echo '<td>';
+        $links = array();
+        foreach ($g['ids'] as $pid) {
+            $edit = get_edit_post_link($pid);
+            $t    = get_the_title($pid);
+            $links[] = $edit
+                ? '<a href="' . esc_url($edit) . '">' . esc_html($t) . '</a>'
+                : esc_html($t);
+        }
+        echo implode(', ', $links); // Each link is individually escaped above.
+        echo '</td></tr>';
+    }
+    echo '</tbody></table>';
 }
 
 /* -------------------------------------------------------------------------
@@ -148,6 +595,10 @@ function ybme_install_history_table() {
 
     require_once ABSPATH . 'wp-admin/includes/upgrade.php';
     dbDelta($sql);
+
+    // Let feature modules create their own tables during the same upgrade.
+    do_action('ybme_install_tables');
+
     update_option('ybme_db_version', YBME_VERSION);
 }
 
@@ -165,6 +616,8 @@ function ybme_log_change($post_id, $meta_key, $old_value, $new_value) {
     if ((string) $old_value === (string) $new_value) {
         return; // Nothing actually changed.
     }
+    // A meta value changed, so any cached audit is now stale.
+    ybme_clear_audit_cache();
     global $wpdb;
     $wpdb->insert(
         ybme_history_table(),
@@ -187,13 +640,37 @@ function ybme_log_change($post_id, $meta_key, $old_value, $new_value) {
 register_activation_hook(__FILE__, 'ybme_activate');
 register_deactivation_hook(__FILE__, 'ybme_deactivate');
 
+/**
+ * Back-compat shim: true when Yoast specifically is available. Prefer
+ * ybme_provider_active() for "can we read/write meta at all".
+ */
+function ybme_yoast_active() {
+    return ybme_provider_is_available('yoast');
+}
+
+/**
+ * Warn (but don't fatal) when no supported SEO plugin is active. Without one,
+ * every meta key this plugin writes would be orphaned.
+ */
+add_action('admin_notices', 'ybme_provider_missing_notice');
+function ybme_provider_missing_notice() {
+    if (ybme_provider_active() || !current_user_can(YBME_CAPABILITY)) {
+        return;
+    }
+    $screen = get_current_screen();
+    if (!$screen || strpos($screen->id, 'yoast-bulk-meta-editor') === false) {
+        return;
+    }
+    echo '<div class="notice notice-error"><p>' . esc_html__('Bulk Meta Editor needs a supported SEO plugin (Yoast SEO, Rank Math or SEOPress) to be active. Editing is disabled until one is enabled.', YBME_TEXT_DOMAIN) . '</p></div>';
+}
+
 function check_for_yoast_seo()
 {
-    if (!is_plugin_active('wordpress-seo/wp-seo.php') && current_user_can('activate_plugins')) {
-        // Stop activation redirect and show error
+    if (!ybme_provider_active() && current_user_can('activate_plugins')) {
+        // Stop activation redirect and show error.
         wp_die(sprintf(
             /* translators: %s: plugins admin url */
-            __('Sorry, but this plugin requires Yoast SEO to be installed and active. <br><a href="%s">&laquo; Return to Plugins</a>', YBME_TEXT_DOMAIN),
+            __('Sorry, but this plugin requires a supported SEO plugin (Yoast SEO, Rank Math or SEOPress) to be installed and active. <br><a href="%s">&laquo; Return to Plugins</a>', YBME_TEXT_DOMAIN),
             admin_url('plugins.php')
         ));
     }
@@ -229,23 +706,29 @@ function ybme_deactivate() {
 
 add_action("update_option_ybme_roles", function($old, $new) { ybme_apply_role_capabilities($new); }, 10, 2);
 
-// Hook into the admin menu
+// Switching provider changes which meta keys the audit reads, so drop its cache.
+add_action("update_option_ybme_provider", 'ybme_clear_audit_cache');
+
+// Hook into the admin menu and settings registration at the top level. These
+// were previously coupled (settings were registered inside the admin_menu
+// callback), which only worked because admin_menu happens to fire before
+// admin_init. Register each on its own hook.
 add_action('admin_menu', 'yoast_bulk_meta_editor_create_menu');
+add_action('admin_init', 'register_yoast_bulk_meta_editor_settings');
 
 // Create new top-level menu
 function yoast_bulk_meta_editor_create_menu() {
     // Create new top-level menu
     add_menu_page(__('Yoast Bulk Meta Editor', YBME_TEXT_DOMAIN), __('Yoast Bulk Meta Editor', YBME_TEXT_DOMAIN), YBME_CAPABILITY, 'yoast-bulk-meta-editor', 'yoast_bulk_meta_editor_page' );
 
+    // Site-wide SEO audit dashboard.
+    add_submenu_page('yoast-bulk-meta-editor', __('SEO Audit', YBME_TEXT_DOMAIN), __('Audit', YBME_TEXT_DOMAIN), YBME_CAPABILITY, 'yoast-bulk-meta-editor-audit', 'ybme_audit_page');
+
     // History / audit log
     add_submenu_page('yoast-bulk-meta-editor', __('Change History', YBME_TEXT_DOMAIN), __('History', YBME_TEXT_DOMAIN), YBME_CAPABILITY, 'yoast-bulk-meta-editor-history', 'ybme_history_page');
 
     // Create submenu for settings
     add_submenu_page('yoast-bulk-meta-editor', __('Yoast Bulk Meta Editor Settings', YBME_TEXT_DOMAIN), __('Settings', YBME_TEXT_DOMAIN), 'manage_options', 'yoast-bulk-meta-editor-settings', 'yoast_bulk_meta_editor_settings_page');
-
-
-    // Call register settings function
-    add_action('admin_init', 'register_yoast_bulk_meta_editor_settings');
 }
 
 /**
@@ -273,11 +756,12 @@ function ybme_render_meta_row($post, $enabled_columns, $lang_flags = array(), $s
     $edit_link  = get_edit_post_link($post_id);
     $permalink  = get_permalink($post_id);
     $post_type  = get_post_type($post_id);
-    $meta_title = get_post_meta($post_id, '_yoast_wpseo_title', true);
-    $meta_desc  = get_post_meta($post_id, '_yoast_wpseo_metadesc', true);
-    $keyword    = get_post_meta($post_id, '_yoast_wpseo_focuskw', true);
-    $canonical  = get_post_meta($post_id, '_yoast_wpseo_canonical', true);
-    $social     = get_post_meta($post_id, '_yoast_wpseo_opengraph-title', true);
+    $fk         = ybme_provider_field_keys();
+    $meta_title = get_post_meta($post_id, $fk['meta_title'], true);
+    $meta_desc  = get_post_meta($post_id, $fk['meta_description'], true);
+    $keyword    = get_post_meta($post_id, $fk['keyword'], true);
+    $canonical  = get_post_meta($post_id, $fk['canonical_url'], true);
+    $social     = get_post_meta($post_id, $fk['social_title'], true);
 
     $cat_slugs = wp_get_post_terms($post_id, 'category', array('fields' => 'slugs'));
     if (is_wp_error($cat_slugs)) {
@@ -301,7 +785,14 @@ function ybme_render_meta_row($post, $enabled_columns, $lang_flags = array(), $s
     }
     $row .= '>';
 
+    // Only render columns that currently exist, so the body can never drift
+    // from the header (e.g. a GSC column left enabled after disconnecting).
+    $available = ybme_get_available_columns();
+
     foreach ($enabled_columns as $col) {
+        if (!isset($available[$col])) {
+            continue;
+        }
         switch ($col) {
             case 'seo_score':
                 $row .= '<td class="ybme-seo-score"><span class="ybme-score-dot" aria-hidden="true"></span></td>';
@@ -317,19 +808,27 @@ function ybme_render_meta_row($post, $enabled_columns, $lang_flags = array(), $s
                 $row .= '<td>' . esc_html(ucfirst($post_type)) . '</td>';
                 break;
             case 'meta_title':
-                $row .= '<td class="editable" data-meta-key="_yoast_wpseo_title">' . esc_html($meta_title) . '</td>';
+                $row .= '<td class="editable" data-meta-key="' . esc_attr($fk['meta_title']) . '">' . esc_html($meta_title) . '</td>';
                 break;
             case 'meta_description':
-                $row .= '<td class="editable" data-meta-key="_yoast_wpseo_metadesc">' . esc_html($meta_desc) . '</td>';
+                $row .= '<td class="editable" data-meta-key="' . esc_attr($fk['meta_description']) . '">' . esc_html($meta_desc) . '</td>';
                 break;
             case 'keyword':
-                $row .= '<td class="editable" data-meta-key="_yoast_wpseo_focuskw">' . esc_html($keyword) . '</td>';
+                $row .= '<td class="editable" data-meta-key="' . esc_attr($fk['keyword']) . '">' . esc_html($keyword) . '</td>';
                 break;
             case 'canonical_url':
-                $row .= '<td class="editable" data-meta-key="_yoast_wpseo_canonical">' . esc_html($canonical) . '</td>';
+                $row .= '<td class="editable" data-meta-key="' . esc_attr($fk['canonical_url']) . '">' . esc_html($canonical) . '</td>';
                 break;
             case 'social_title':
-                $row .= '<td class="editable" data-meta-key="_yoast_wpseo_opengraph-title">' . esc_html($social) . '</td>';
+                $row .= '<td class="editable" data-meta-key="' . esc_attr($fk['social_title']) . '">' . esc_html($social) . '</td>';
+                break;
+            default:
+                /**
+                 * Render a cell for a column this core switch doesn't know
+                 * about. Handlers must return a complete, escaped <td>. Used by
+                 * feature modules such as Search Console.
+                 */
+                $row .= apply_filters('ybme_render_column_cell', '<td></td>', $col, $post_id, $permalink);
                 break;
         }
     }
@@ -341,7 +840,7 @@ function ybme_render_meta_row($post, $enabled_columns, $lang_flags = array(), $s
 function yoast_bulk_meta_editor_page()
 {
     if (!current_user_can(YBME_CAPABILITY)) { wp_die(); }
-    $posts_per_page = intval(get_option('ybme_rows_per_page', YBME_POSTS_PER_PAGE));
+    $posts_per_page = ybme_get_rows_per_page();
     $enabled_columns = ybme_get_enabled_columns();
     $selected_langs = array();
     $lang_flags = array();
@@ -463,6 +962,11 @@ function yoast_bulk_meta_editor_page()
     echo '<div style="text-align: center; margin-top: 20px;">';
     echo '<button id="save-btn" style="background-color: #4CAF50; color: white; padding: 10px 20px; margin-right: 10px; border: none; border-radius: 5px; cursor: pointer;">' . esc_html__('Save Changes', YBME_TEXT_DOMAIN) . '</button>';
     echo '<button id="undo-btn" style="background-color: #777; color: white; padding: 10px 20px; margin-right: 10px; border: none; border-radius: 5px; cursor: pointer;">' . esc_html__('Undo Last Change', YBME_TEXT_DOMAIN) . '</button>';
+    /**
+     * Inject extra editor action controls (e.g. the "Submit for Review"
+     * button from the pending-changes module).
+     */
+    do_action('ybme_editor_actions');
     echo '<a href="https://www.buymeacoffee.com/costinbotez" target="_blank" rel="noopener noreferrer" style="background-color: #FF813F; color: #ffffff; padding: 10px 20px; text-decoration: none; border-radius: 5px;">' . esc_html__('Support the plugin 🙌', YBME_TEXT_DOMAIN) . '</a>';
     echo '</div>';
     echo '<ul id="history-log" style="margin-top: 20px;"></ul>';
@@ -516,15 +1020,107 @@ function ybme_history_page() {
     echo '</div>';
 }
 
+/* -------------------------------------------------------------------------
+ * Settings sanitization
+ *
+ * Every registered option runs through one of these so a crafted options.php
+ * POST can never store an unexpected post type, column, role, key or value.
+ * ---------------------------------------------------------------------- */
+
+// Keep only values that are real, public post types.
+function ybme_sanitize_post_types($value) {
+    $public = get_post_types(array('public' => true), 'names');
+    $clean  = array();
+    if (is_array($value)) {
+        foreach ($value as $type) {
+            $type = sanitize_key($type);
+            if (in_array($type, $public, true)) {
+                $clean[] = $type;
+            }
+        }
+    }
+    // Never let the editor end up with zero post types to query.
+    return empty($clean) ? array('post', 'page') : array_values(array_unique($clean));
+}
+
+// Keep only columns the plugin actually knows how to render.
+function ybme_sanitize_columns($value) {
+    $available = array_keys(ybme_get_available_columns());
+    $clean     = array();
+    if (is_array($value)) {
+        foreach ($value as $col) {
+            $col = sanitize_key($col);
+            if (in_array($col, $available, true)) {
+                $clean[] = $col;
+            }
+        }
+    }
+    return array_values(array_unique($clean));
+}
+
+// Keep only roles that exist on this site.
+function ybme_sanitize_roles($value) {
+    $editable = array_keys(get_editable_roles());
+    $clean    = array();
+    if (is_array($value)) {
+        foreach ($value as $role) {
+            $role = sanitize_key($role);
+            if (in_array($role, $editable, true)) {
+                $clean[] = $role;
+            }
+        }
+    }
+    // Administrators must always retain access.
+    if (!in_array('administrator', $clean, true)) {
+        $clean[] = 'administrator';
+    }
+    return array_values(array_unique($clean));
+}
+
+// Accept only a known provider id, or '' for auto-detect.
+function ybme_sanitize_provider($value) {
+    $value = sanitize_key($value);
+    return isset(ybme_providers()[$value]) ? $value : '';
+}
+
+// Clamp rows-per-page to a sane range so the editor can't be made to query
+// thousands of posts in a single request.
+function ybme_sanitize_rows_per_page($value) {
+    $value = intval($value);
+    if ($value < 1) {
+        $value = YBME_POSTS_PER_PAGE;
+    }
+    if ($value > 200) {
+        $value = 200;
+    }
+    return $value;
+}
+
+// Keep only language codes WPML actually reports.
+function ybme_sanitize_languages($value) {
+    $known = array_keys(ybme_get_wpml_languages());
+    $clean = array();
+    if (is_array($value)) {
+        foreach ($value as $code) {
+            $code = sanitize_key($code);
+            if (in_array($code, $known, true)) {
+                $clean[] = $code;
+            }
+        }
+    }
+    return array_values(array_unique($clean));
+}
+
 // Register our settings
 function register_yoast_bulk_meta_editor_settings() {
-    register_setting('yoast-bulk-meta-editor-settings-group', 'post_types');
-    register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_enabled_columns');
-    register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_license_key');
-    register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_roles');
-    register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_rows_per_page');
+    register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_provider', array('sanitize_callback' => 'ybme_sanitize_provider'));
+    register_setting('yoast-bulk-meta-editor-settings-group', 'post_types', array('sanitize_callback' => 'ybme_sanitize_post_types'));
+    register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_enabled_columns', array('sanitize_callback' => 'ybme_sanitize_columns'));
+    register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_license_key', array('sanitize_callback' => 'sanitize_text_field'));
+    register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_roles', array('sanitize_callback' => 'ybme_sanitize_roles'));
+    register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_rows_per_page', array('sanitize_callback' => 'ybme_sanitize_rows_per_page'));
     if (ybme_wpml_active()) {
-        register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_languages');
+        register_setting('yoast-bulk-meta-editor-settings-group', 'ybme_languages', array('sanitize_callback' => 'ybme_sanitize_languages'));
     }
 }
 
@@ -545,7 +1141,32 @@ function yoast_bulk_meta_editor_settings_page() {
             <?php settings_fields('yoast-bulk-meta-editor-settings-group'); ?>
             <?php do_settings_sections('yoast-bulk-meta-editor-settings-group'); ?>
 
-            <h2><?php echo esc_html__('Select post types:', YBME_TEXT_DOMAIN); ?></h2>
+            <h2><?php echo esc_html__('SEO plugin:', YBME_TEXT_DOMAIN); ?></h2>
+            <?php
+                $providers        = ybme_providers();
+                $saved_provider   = get_option('ybme_provider', '');
+                $active_provider  = ybme_active_provider_id();
+                $active_label     = $active_provider ? $providers[$active_provider]['label'] : __('none detected', YBME_TEXT_DOMAIN);
+            ?>
+            <p class="description">
+                <?php echo esc_html(sprintf(
+                    /* translators: %s: name of the detected SEO plugin */
+                    __('Currently editing: %s', YBME_TEXT_DOMAIN),
+                    $active_label
+                )); ?>
+            </p>
+            <select name="ybme_provider">
+                <option value="" <?php selected($saved_provider, ''); ?>><?php echo esc_html__('Auto-detect', YBME_TEXT_DOMAIN); ?></option>
+                <?php foreach ($providers as $pid => $p) :
+                    $avail = ybme_provider_is_available($pid); ?>
+                    <option value="<?php echo esc_attr($pid); ?>" <?php selected($saved_provider, $pid); disabled(!$avail); ?>>
+                        <?php echo esc_html($p['label']); ?><?php echo $avail ? '' : ' ' . esc_html__('(not active)', YBME_TEXT_DOMAIN); ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+            <p class="description"><?php echo esc_html__('Yoast SEO, Rank Math and SEOPress are supported. (All in One SEO stores its data differently and is not yet supported.)', YBME_TEXT_DOMAIN); ?></p>
+
+            <h2 style="margin-top:20px;"><?php echo esc_html__('Select post types:', YBME_TEXT_DOMAIN); ?></h2>
 
             <?php
                 foreach ($all_post_types as $post_type) {
@@ -576,8 +1197,8 @@ function yoast_bulk_meta_editor_settings_page() {
 
             <h2 style="margin-top:20px;"><?php echo esc_html__('Rows per page:', YBME_TEXT_DOMAIN); ?></h2>
             <?php
-                $rows = intval(get_option('ybme_rows_per_page', YBME_POSTS_PER_PAGE));
-                echo '<input type="number" min="1" style="width:60px;" name="ybme_rows_per_page" value="' . esc_attr($rows) . '" />';
+                $rows = ybme_get_rows_per_page();
+                echo '<input type="number" min="1" max="200" style="width:60px;" name="ybme_rows_per_page" value="' . esc_attr($rows) . '" />';
             ?>
 
             <h2 style="margin-top:20px;"><?php echo esc_html__('Allowed Roles:', YBME_TEXT_DOMAIN); ?></h2>
@@ -624,13 +1245,22 @@ function enqueue_admin_scripts($hook)
 
         // Enqueue our custom script
         wp_enqueue_script('bulk-meta-editor', plugins_url('/js/bulk-meta-editor.js', __FILE__), array('jquery', 'jquery-tablesorter', 'jquery-ui-sortable'), YBME_VERSION, true);
-        $rows = intval(get_option('ybme_rows_per_page', YBME_POSTS_PER_PAGE));
-        wp_localize_script('bulk-meta-editor', 'bulk_editor_vars', array(
+        $rows = ybme_get_rows_per_page();
+        /**
+         * Filter the data localized to the editor script so feature modules
+         * can add their own flags and i18n strings.
+         */
+        $editor_vars = apply_filters('ybme_editor_js_vars', array(
             'posts_per_page' => $rows,
             'nonce'          => wp_create_nonce(YBME_NONCE_ACTION),
+            'field_keys'     => ybme_provider_field_keys(),
             'i18n' => array(
                 'meta_updated'    => __('Meta info updated successfully', YBME_TEXT_DOMAIN),
                 'update_failed'   => __('Failed to update meta info', YBME_TEXT_DOMAIN),
+                'save_none'       => __('No changes to save', YBME_TEXT_DOMAIN),
+                'save_summary'    => __('%d change(s) saved', YBME_TEXT_DOMAIN),
+                'save_partial'    => __('%1$d saved, %2$d skipped (no permission)', YBME_TEXT_DOMAIN),
+                'unsaved_warning' => __('You have unsaved changes. Leave this page and discard them?', YBME_TEXT_DOMAIN),
                 'nothing_to_undo' => __('Nothing to undo', YBME_TEXT_DOMAIN),
                 'change_reverted' => __('Change reverted', YBME_TEXT_DOMAIN),
                 'revert_failed'   => __('Failed to revert change', YBME_TEXT_DOMAIN),
@@ -656,8 +1286,15 @@ function enqueue_admin_scripts($hook)
                 'score_good'          => __('Looks good', YBME_TEXT_DOMAIN),
             ),
         ));
+        wp_localize_script('bulk-meta-editor', 'bulk_editor_vars', $editor_vars);
 
         // Enqueue our custom styles
+        wp_enqueue_style('bulk-meta-editor', plugins_url('/css/style.css', __FILE__), array(), YBME_VERSION, 'all');
+        return;
+    }
+
+    // Audit dashboard (styles only).
+    if ($page === 'yoast-bulk-meta-editor-audit') {
         wp_enqueue_style('bulk-meta-editor', plugins_url('/css/style.css', __FILE__), array(), YBME_VERSION, 'all');
         return;
     }
@@ -682,6 +1319,7 @@ function save_meta_info()
 {
     check_ajax_referer(YBME_NONCE_ACTION, 'nonce');
     if (!current_user_can(YBME_CAPABILITY)) { wp_send_json_error(); }
+    if (!ybme_provider_active()) { wp_send_json_error(array('message' => __('No supported SEO plugin is active.', YBME_TEXT_DOMAIN))); }
 
     $post_id  = isset($_POST['post_id']) ? intval($_POST['post_id']) : 0;
     $meta_key = isset($_POST['meta_key']) ? sanitize_text_field(wp_unslash($_POST['meta_key'])) : '';
@@ -702,6 +1340,57 @@ function save_meta_info()
     wp_send_json_success(array('value' => $value));
 }
 
+add_action('wp_ajax_ybme_save_meta_batch', 'ybme_save_meta_batch');
+/**
+ * Save many meta changes in a single request. The client sends a JSON map of
+ * { post_id: { meta_key: value, ... }, ... }. Each field is validated against
+ * the allow-list and per-post edit permission exactly like the single save.
+ */
+function ybme_save_meta_batch()
+{
+    check_ajax_referer(YBME_NONCE_ACTION, 'nonce');
+    if (!current_user_can(YBME_CAPABILITY)) { wp_send_json_error(); }
+    if (!ybme_provider_active()) { wp_send_json_error(array('message' => __('No supported SEO plugin is active.', YBME_TEXT_DOMAIN))); }
+
+    // $_POST is slash-escaped by WordPress; unslash before decoding the JSON.
+    $raw     = isset($_POST['changes']) ? wp_unslash($_POST['changes']) : '';
+    $changes = json_decode($raw, true);
+    if (!is_array($changes) || empty($changes)) {
+        wp_send_json_error(array('message' => __('No changes to save.', YBME_TEXT_DOMAIN)));
+    }
+
+    $allowed = ybme_allowed_meta_keys();
+    $saved   = 0;
+    $skipped = 0;
+    $results = array();
+
+    foreach ($changes as $post_id => $fields) {
+        $post_id = intval($post_id);
+        if ($post_id <= 0 || !is_array($fields)) {
+            $skipped++;
+            continue;
+        }
+        if (!current_user_can('edit_post', $post_id)) {
+            $skipped++;
+            continue;
+        }
+        foreach ($fields as $meta_key => $value) {
+            if (!in_array($meta_key, $allowed, true)) {
+                $skipped++;
+                continue;
+            }
+            $value = ybme_sanitize_meta_value($meta_key, (string) $value);
+            $old   = get_post_meta($post_id, $meta_key, true);
+            update_post_meta($post_id, $meta_key, wp_slash($value));
+            ybme_log_change($post_id, $meta_key, $old, $value);
+            $saved++;
+            $results[] = array('post_id' => $post_id, 'meta_key' => $meta_key, 'value' => $value);
+        }
+    }
+
+    wp_send_json_success(array('saved' => $saved, 'skipped' => $skipped, 'results' => $results));
+}
+
 add_action('wp_ajax_load_more_posts', 'yoast_bulk_meta_editor_load_more_posts');
 function yoast_bulk_meta_editor_load_more_posts()
 {
@@ -709,7 +1398,7 @@ function yoast_bulk_meta_editor_load_more_posts()
     if (!current_user_can(YBME_CAPABILITY)) { wp_die(); }
     $offset = isset($_POST['offset']) ? intval($_POST['offset']) : 0;
     $enabled_columns = ybme_get_enabled_columns();
-    $rows = intval(get_option('ybme_rows_per_page', YBME_POSTS_PER_PAGE));
+    $rows = ybme_get_rows_per_page();
     $args = array(
         'numberposts' => $rows,
         'offset'      => $offset,
@@ -742,10 +1431,11 @@ function yoast_bulk_meta_editor_load_more_posts()
  * ---------------------------------------------------------------------- */
 
 function ybme_fr_field_to_key($field) {
-    $map = array(
-        'meta_title'       => '_yoast_wpseo_title',
-        'meta_description' => '_yoast_wpseo_metadesc',
-        'keyword'          => '_yoast_wpseo_focuskw',
+    $keys = ybme_provider_field_keys();
+    $map  = array(
+        'meta_title'       => $keys['meta_title'],
+        'meta_description' => $keys['meta_description'],
+        'keyword'          => $keys['keyword'],
     );
     return isset($map[$field]) ? $map[$field] : '';
 }
@@ -785,6 +1475,9 @@ function ybme_find_replace_handler($apply) {
     if (!current_user_can(YBME_CAPABILITY)) {
         wp_send_json_error(array('message' => __('Permission denied.', YBME_TEXT_DOMAIN)));
     }
+    if ($apply && !ybme_provider_active()) {
+        wp_send_json_error(array('message' => __('No supported SEO plugin is active.', YBME_TEXT_DOMAIN)));
+    }
 
     $field    = isset($_POST['field']) ? sanitize_text_field(wp_unslash($_POST['field'])) : '';
     $meta_key = ybme_fr_field_to_key($field);
@@ -799,6 +1492,12 @@ function ybme_find_replace_handler($apply) {
 
     if ($find === '') {
         wp_send_json_error(array('message' => __('Enter text to find.', YBME_TEXT_DOMAIN)));
+    }
+
+    // Cap pattern length to limit exposure to catastrophic-backtracking (ReDoS)
+    // patterns run across every post.
+    if (strlen($find) > 1000 || strlen($replace) > 2000) {
+        wp_send_json_error(array('message' => __('Find or replace text is too long.', YBME_TEXT_DOMAIN)));
     }
 
     if ($regex) {
@@ -869,6 +1568,9 @@ function ybme_revert_change() {
     check_ajax_referer(YBME_NONCE_ACTION, 'nonce');
     if (!current_user_can(YBME_CAPABILITY)) {
         wp_send_json_error();
+    }
+    if (!ybme_provider_active()) {
+        wp_send_json_error(array('message' => __('No supported SEO plugin is active.', YBME_TEXT_DOMAIN)));
     }
     $id = isset($_POST['id']) ? intval($_POST['id']) : 0;
     if ($id <= 0) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Uninstall cleanup for Yoast SEO Bulk Meta Editor.
+ *
+ * Runs only when the user deletes the plugin from the Plugins screen. Removes
+ * the plugin's own options, custom capability and history table. Post meta
+ * belongs to Yoast, not to us, so it is intentionally left untouched.
+ */
+
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+    exit;
+}
+
+// Options this plugin creates.
+$ybme_options = array(
+    'post_types',
+    'ybme_provider',
+    'ybme_enabled_columns',
+    'ybme_license_key',
+    'ybme_roles',
+    'ybme_rows_per_page',
+    'ybme_languages',
+    'ybme_db_version',
+    'ybme_gsc_client_id',
+    'ybme_gsc_client_secret',
+    'ybme_gsc_tokens',
+    'ybme_gsc_site',
+    'ybme_ai_provider',
+    'ybme_ai_key',
+    'ybme_ai_model',
+);
+foreach ($ybme_options as $ybme_option) {
+    delete_option($ybme_option);
+}
+
+// Remove cached transients.
+delete_transient('ybme_audit_cache');
+delete_transient('ybme_gsc_data');
+
+// Clear scheduled crons.
+wp_clear_scheduled_hook('ybme_gsc_refresh_cron');
+wp_clear_scheduled_hook('ybme_pending_cron');
+
+// Remove the custom capability from every role.
+if (function_exists('wp_roles')) {
+    foreach (wp_roles()->roles as $ybme_role => $ybme_info) {
+        $ybme_obj = get_role($ybme_role);
+        if ($ybme_obj) {
+            $ybme_obj->remove_cap('manage_ybme_meta');
+        }
+    }
+}
+
+// Drop the plugin's custom tables.
+global $wpdb;
+foreach (array('ybme_history', 'ybme_pending') as $ybme_suffix) {
+    $ybme_table = $wpdb->prefix . $ybme_suffix;
+    $wpdb->query("DROP TABLE IF EXISTS {$ybme_table}");
+}


### PR DESCRIPTION
## Summary

Expands the plugin from a Yoast-only bulk meta editor into a broader SEO toolkit. Work spans versions **1.6.1 → 1.12.0** (all previously uncommitted).

## What's included

| Version | Feature |
|---------|---------|
| **1.6.1** | Security hardening: settings sanitization, rows-per-page clamp (1–200), find/replace input caps (ReDoS), `uninstall.php` cleanup, directory guards, runtime SEO-plugin check |
| **1.7.0** | Batched save (one request instead of one-per-field), unsaved-changes guard + dirty-cell markers, top-level settings hook, Composer + PHPCS (WPCS) + GitHub Actions CI |
| **1.8.0** | Site-wide **SEO Audit** dashboard: score distribution, issue & post-type breakdowns, cross-post duplicate-meta detection, deep links into the editor |
| **1.9.0** | **Multi-plugin support**: provider abstraction for **Yoast SEO, Rank Math, SEOPress** with auto-detection + settings selector (AIOSEO excluded — custom table, not post meta) |
| **1.10.0** | **Google Search Console**: OAuth connection + optional clicks/impressions/CTR/position columns, cached with a daily cron |
| **1.11.0** | **Draft & scheduled changes**: submit-for-review queue, admin approve/reject, cron-applied scheduling — validated & logged like a direct save |
| **1.12.0** | **AI meta generation**: per-row + bulk generation via the user's own Claude/OpenAI key, always shown as previews to approve |

## Architecture

- New `includes/` module layer (`gsc.php`, `pending.php`, `ai.php`) wired through five extension hooks: `ybme_available_columns`, `ybme_render_column_cell`, `ybme_editor_actions`, `ybme_editor_js_vars`, `ybme_install_tables`.
- Provider abstraction removes all hard-coded `_yoast_wpseo_*` keys from the editor, audit, find/replace and save paths.

## Testing

Live-tested on WordPress (Local) with Yoast active:

- ✅ Clean activation; `ybme_history` + `ybme_pending` tables created
- ✅ All 7 admin pages render with **0 errors**
- ✅ Audit (14 posts → 8 good / 1 warn / 5 bad) matches the editor score dots
- ✅ Inline edit with live char counter + SERP preview
- ✅ Pending approve-now + scheduled-cron apply, both logged to history
- ✅ Provider selector shows Yoast active, Rank Math/SEOPress disabled (not installed)
- ✅ GSC/AI columns appear only once configured
- 🐛 **Fixed during testing**: module submenus registered before the parent menu → "not allowed to access this page"; now registered at `admin_menu` priority 20

### Not exercised (needs real credentials)
- Google OAuth + Search Console API round-trip
- A live Claude/OpenAI API call (surrounding plumbing verified)

## Notes
- Display name is still "Yoast SEO Bulk Meta Editor" — renaming (and the WordPress.org trademark rule) is a separate branding decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
